### PR TITLE
PE-50: Describe price calculation as estimation rather than total

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-await-in-loop */
 // index.ts
 import * as ardrive from 'ardrive-core-js';
+import { ArDriveCommunityOracle } from 'ardrive-core-js';
 import * as cli from './prompts';
 
 async function main() {
@@ -21,6 +22,9 @@ async function main() {
 		autoSyncApproval: 0
 	};
 	let fileDownloadConflicts: ardrive.ArFSFileMetaData[] = [];
+
+	// Start background task to fetch ArDrive community tip setting
+	new ArDriveCommunityOracle().setExactTipSettingInBackground();
 
 	// Ask the user for their login name
 	const login = await cli.promptForLogin();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-await-in-loop */
 // index.ts
 import * as ardrive from 'ardrive-core-js';
-import { ArDriveCommunityOracle } from 'ardrive-core-js';
+import { arDriveCommunityOracle } from 'ardrive-core-js';
 import * as cli from './prompts';
 
 async function main() {
@@ -24,7 +24,7 @@ async function main() {
 	let fileDownloadConflicts: ardrive.ArFSFileMetaData[] = [];
 
 	// Start background task to fetch ArDrive community tip setting
-	new ArDriveCommunityOracle().setExactTipSettingInBackground();
+	arDriveCommunityOracle.setExactTipSettingInBackground();
 
 	// Ask the user for their login name
 	const login = await cli.promptForLogin();

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -474,7 +474,7 @@ const promptForArDriveUpload = async (
 	autoSyncApproval: number
 ): Promise<boolean> => {
 	console.log(
-		'Uploading %s files, %s folders and %s changes (%s) to the Permaweb, totalling %s AR / %s USD',
+		'Uploading %s files, %s folders and %s changes (%s) to the Permaweb, estimated cost: %s AR / %s USD',
 		uploadBatch.totalNumberOfFileUploads,
 		uploadBatch.totalNumberOfFolderUploads,
 		uploadBatch.totalNumberOfMetaDataUploads,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -474,7 +474,7 @@ const promptForArDriveUpload = async (
 	autoSyncApproval: number
 ): Promise<boolean> => {
 	console.log(
-		'Uploading %s files, %s folders and %s changes (%s) to the Permaweb, estimated cost: %s AR / %s USD',
+		'Uploading %s files, %s folders and %s changes (%s) to the Permaweb with estimated cost: %s AR / %s USD',
 		uploadBatch.totalNumberOfFileUploads,
 		uploadBatch.totalNumberOfFolderUploads,
 		uploadBatch.totalNumberOfMetaDataUploads,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -58,7 +58,7 @@ const promptForBackupWalletPath = (): string => {
 	if (backupFolderPath === '') {
 		return backupFolderPath;
 	} else {
-		const validPath: string = checkOrCreateFolder(backupFolderPath)
+		const validPath: string = checkOrCreateFolder(backupFolderPath);
 		if (validPath === '0') {
 			return promptForBackupWalletPath();
 		}


### PR DESCRIPTION
There is a natural delay between price estimation and when the total AR taken from the user's wallet. This estimation can be improved in core-js, but when uploading many larger files the delay becomes larger and a volatile AR price could be much different in 10-15 minutes when a large transaction has settled.

This PR simply clarifies that the prompt is an estimation, rather than the total that will be charged.