### PR TITLE
chore(version): Use core version `0.4.0` PE-95

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"dependencies": {
 		"@types/node": "^14.14.32",
 		"@types/uuid": "^8.3.0",
-		"ardrive-core-js": "REPLACE WITH you local ardrive-core",
+		"ardrive-core-js": "0.4.0",
 		"arweave": "1.10.11",
 		"arweave-bundles": "^1.0.3",
 		"community-js": "^1.1.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-cli",
-	"version": "0.2.12",
+	"version": "0.3.0",
 	"description": "The ArDrive Command Line Interface (CLI) contains all of the needed security, file synchronization and Arweave wallet capabilities via a node.js application.",
 	"main": "./lib/index.js",
 	"bin": "./lib/index.js",


### PR DESCRIPTION
This PR locks the CLI to `ardrive-core-js` version `0.4.0` and increments CLI version to `0.3.0` in preparation for releasing Core/CLI as npm packages