### PR TITLE
chore(dev-reload): Add tsc watch command to reload dev env PE-204

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"build": "yarn clean && tsc",
 		"version": "yarn run format && git add -A src",
 		"postversion": "git push && git push --tags",
-		"start": "yarn run build && node ./lib/index.js"
+		"start": "yarn clean && tsc -w"
 	},
 	"husky": {
 		"hooks": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 		"build": "yarn clean && tsc",
 		"version": "yarn run format && git add -A src",
 		"postversion": "git push && git push --tags",
-		"start": "yarn clean && tsc -w"
+		"start": "yarn run build && node ./lib/index.js",
+		"dev": "yarn clean && tsc -w"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
This PR adjusts the `yarn start` command to use `tsc -w`, which will rebuild the `lib` output on each save.