### PR TITLE
PE-448: fee boost

### DIFF
--- a/src/CLICommand/cli_command.ts
+++ b/src/CLICommand/cli_command.ts
@@ -28,15 +28,19 @@ function setCommanderCommand(commandDescriptor: CommandDescriptor, program: CliA
 	commandDescriptor.parameters.forEach((parameterName) => {
 		const parameter = new Parameter(parameterName);
 		const aliasesAsString = parameter.aliases.join(' ');
-		const paramType = (function () {
+		const paramTypeString = (function () {
 			if (parameter.type === 'array') {
-				return `<${parameterName}...>`;
+				return ` <${parameterName}...>`;
 			} else if (parameter.type === 'boolean') {
 				return '';
 			}
-			return `<${parameterName}>`;
+			return ` <${parameterName}>`;
 		})();
-		const optionArguments = [`${aliasesAsString} ${paramType}`, parameter.description, parameter.default] as const;
+		const optionArguments = [
+			`${aliasesAsString}${paramTypeString}`,
+			parameter.description,
+			parameter.default
+		] as const;
 		if (parameter.required) {
 			command.requiredOption(...optionArguments);
 		} else {

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -210,7 +210,7 @@ export class ArDrive extends ArDriveAnonymous {
 					metadataTxId: uploadFileResult.metaDataTrxId,
 					dataTxId: uploadFileResult.dataTrxId,
 					entityId: uploadFileResult.fileId,
-					key: uploadFileResult.fileKey.toString('hex')
+					key: uploadFileResult.fileKey.toString('base64')
 				}
 			],
 			tips: [tipData],
@@ -331,13 +331,13 @@ export class ArDrive extends ArDriveAnonymous {
 					type: 'drive',
 					metadataTxId: createDriveResult.driveTrxId,
 					entityId: createDriveResult.driveId,
-					key: createDriveResult.driveKey.toString('hex')
+					key: createDriveResult.driveKey.toString('base64')
 				},
 				{
 					type: 'folder',
 					metadataTxId: createDriveResult.rootFolderTrxId,
 					entityId: createDriveResult.rootFolderId,
-					key: createDriveResult.driveKey.toString('hex')
+					key: createDriveResult.driveKey.toString('base64')
 				}
 			],
 			tips: [],

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -8,7 +8,7 @@ import {
 	winstonToAr
 } from 'ardrive-core-js';
 import * as fs from 'fs';
-import { ArFSDAOType, ArFSDAOAnonymous, ArFSPublicDrive, ArFSDAO } from './arfsdao';
+import { ArFSDAOType, ArFSDAOAnonymous, ArFSPublicDrive, ArFSDAO, ArFSPrivateDrive } from './arfsdao';
 import { TransactionID, ArweaveAddress, Winston, DriveID, FolderID, Bytes, TipType } from './types';
 import { WalletDAO, Wallet, JWKWallet } from './wallet_new';
 import { ARDataPriceRegressionEstimator } from './utils/ar_data_price_regression_estimator';
@@ -272,7 +272,7 @@ export class ArDrive extends ArDriveAnonymous {
 		});
 	}
 
-	async getPrivateDrive(driveId: DriveID, drivePassword: string): Promise<ArFSPublicDrive> {
+	async getPrivateDrive(driveId: DriveID, drivePassword: string): Promise<ArFSPrivateDrive> {
 		const driveEntity = await this.arFsDao.getPrivateDrive(driveId, drivePassword);
 		return Promise.resolve(driveEntity);
 	}

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -88,7 +88,8 @@ export class ArDrive extends ArDriveAnonymous {
 		private readonly appName: string,
 		private readonly appVersion: string,
 		private readonly priceEstimator: ARDataPriceEstimator = new ARDataPriceRegressionEstimator(true),
-		private readonly feeMultiple: FeeMultiple = 1.0
+		private readonly feeMultiple: FeeMultiple = 1.0,
+		private readonly dryRun: boolean = false
 	) {
 		super(arFsDao);
 	}
@@ -108,6 +109,7 @@ export class ArDrive extends ArDriveAnonymous {
 			this.wallet,
 			tokenHolder,
 			{ reward: arTransferBaseFee.toString(), feeMultiple: this.feeMultiple },
+			this.dryRun,
 			this.getTipTags()
 		);
 

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -18,6 +18,7 @@ import {
 	ArFSPublicFolderTransactionData
 } from './arfs_trx_data_types';
 import { basename } from 'path';
+import { urlEncodeHashKey } from './utils';
 
 export type ArFSEntityDataType = 'drive' | 'folder' | 'file';
 
@@ -210,7 +211,7 @@ export class ArDrive extends ArDriveAnonymous {
 					metadataTxId: uploadFileResult.metaDataTrxId,
 					dataTxId: uploadFileResult.dataTrxId,
 					entityId: uploadFileResult.fileId,
-					key: uploadFileResult.fileKey.toString('base64')
+					key: urlEncodeHashKey(uploadFileResult.fileKey)
 				}
 			],
 			tips: [tipData],
@@ -331,13 +332,13 @@ export class ArDrive extends ArDriveAnonymous {
 					type: 'drive',
 					metadataTxId: createDriveResult.driveTrxId,
 					entityId: createDriveResult.driveId,
-					key: createDriveResult.driveKey.toString('base64')
+					key: urlEncodeHashKey(createDriveResult.driveKey)
 				},
 				{
 					type: 'folder',
 					metadataTxId: createDriveResult.rootFolderTrxId,
 					entityId: createDriveResult.rootFolderId,
-					key: createDriveResult.driveKey.toString('base64')
+					key: urlEncodeHashKey(createDriveResult.driveKey)
 				}
 			],
 			tips: [],

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1,11 +1,23 @@
 import { CommunityOracle } from './community/community_oracle';
-import { DrivePrivacy, GQLTagInterface, winstonToAr } from 'ardrive-core-js';
+import { DrivePrivacy, extToMime, GQLTagInterface, winstonToAr } from 'ardrive-core-js';
 import * as fs from 'fs';
 import { ArFSDAOType, ArFSDAOAnonymous, ArFSPublicDrive, ArFSDAO, ArFSPrivateDrive } from './arfsdao';
-import { TransactionID, ArweaveAddress, Winston, DriveID, FolderID, Bytes, TipType } from './types';
-import { WalletDAO, Wallet } from './wallet_new';
+import { TransactionID, ArweaveAddress, Winston, DriveID, FolderID, Bytes, TipType, FeeMultiple } from './types';
+import { WalletDAO, Wallet, JWKWallet } from './wallet_new';
 import { ARDataPriceRegressionEstimator } from './utils/ar_data_price_regression_estimator';
 import { ARDataPriceEstimator } from './utils/ar_data_price_estimator';
+import {
+	ArFSDriveTransactionData,
+	ArFSFolderTransactionData,
+	ArFSObjectTransactionData,
+	ArFSPrivateDriveTransactionData,
+	ArFSPrivateFileMetadataTransactionData,
+	ArFSPrivateFolderTransactionData,
+	ArFSPublicDriveTransactionData,
+	ArFSPublicFileMetadataTransactionData,
+	ArFSPublicFolderTransactionData
+} from './arfs_trx_data_types';
+import { basename } from 'path';
 
 export type ArFSEntityDataType = 'drive' | 'folder' | 'file';
 
@@ -34,7 +46,22 @@ export interface ArFSResult {
 	fees: ArFSFees;
 }
 
-export type FileUploadCosts = { winstonPrice: Winston; communityWinstonTip: Winston };
+export interface FolderUploadBaseCosts {
+	metaDataBaseReward: Winston;
+}
+
+export interface FileUploadBaseCosts extends FolderUploadBaseCosts {
+	fileDataBaseReward: Winston;
+	communityWinstonTip: Winston;
+}
+
+export interface DriveUploadBaseCosts {
+	driveMetaDataBaseReward: Winston;
+	rootFolderMetaDataBaseReward: Winston;
+}
+
+const stubTransactionID = '0000000000000000000000000000000000000000000';
+const stubEntityID = '00000000-0000-0000-0000-000000000000';
 
 export abstract class ArDriveType {
 	protected abstract readonly arFsDao: ArFSDAOType;
@@ -59,7 +86,8 @@ export class ArDrive extends ArDriveAnonymous {
 		private readonly communityOracle: CommunityOracle,
 		private readonly appName: string,
 		private readonly appVersion: string,
-		private readonly priceEstimator: ARDataPriceEstimator = new ARDataPriceRegressionEstimator(true)
+		private readonly priceEstimator: ARDataPriceEstimator = new ARDataPriceRegressionEstimator(true),
+		private readonly feeMultiple: FeeMultiple = 1.0
 	) {
 		super(arFsDao);
 	}
@@ -69,15 +97,16 @@ export class ArDrive extends ArDriveAnonymous {
 		return fs.statSync(filePath).size;
 	}
 
+	// NOTE: Presumes that there's a sufficient wallet balance
 	async sendCommunityTip(communityWinstonTip: Winston): Promise<TipResult> {
-		// TODO: Assert that there's enough AR available in the wallet
-
 		const tokenHolder: ArweaveAddress = await this.communityOracle.selectTokenHolder();
+		const arTransferBaseFee = await this.priceEstimator.getBaseWinstonPriceForByteCount(0);
 
 		const transferResult = await this.walletDao.sendARToAddress(
 			winstonToAr(+communityWinstonTip),
 			this.wallet,
 			tokenHolder,
+			{ reward: arTransferBaseFee.toString(), feeMultiple: this.feeMultiple },
 			this.getTipTags()
 		);
 
@@ -101,20 +130,25 @@ export class ArDrive extends ArDriveAnonymous {
 		destinationFileName?: string
 	): Promise<ArFSResult> {
 		// TODO: Hoist this elsewhere for bulk uploads
-		const { winstonPrice, communityWinstonTip } = await this.estimateAndAssertCostOfUploadSize(
+		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			this.getFileSize(filePath),
+			this.stubPublicFileMetadata(filePath, destinationFileName),
 			'public'
 		);
 
 		// TODO: Add interactive confirmation of AR price estimation
-
+		const fileDataRewardSettings = { reward: uploadBaseCosts.fileDataBaseReward, feeMultiple: this.feeMultiple };
+		const metadataRewardSettings = { reward: uploadBaseCosts.metaDataBaseReward, feeMultiple: this.feeMultiple };
 		const uploadFileResult = await this.arFsDao.uploadPublicFile(
 			parentFolderId,
 			filePath,
-			winstonPrice.toString(),
+			fileDataRewardSettings,
+			metadataRewardSettings,
 			destinationFileName
 		);
-		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(communityWinstonTip);
+		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(
+			uploadBaseCosts.communityWinstonTip
+		);
 
 		return Promise.resolve({
 			created: [
@@ -146,22 +180,28 @@ export class ArDrive extends ArDriveAnonymous {
 		destinationFileName?: string
 	): Promise<ArFSResult> {
 		// TODO: Hoist this elsewhere for bulk uploads
-		const { winstonPrice, communityWinstonTip } = await this.estimateAndAssertCostOfUploadSize(
+		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			this.getFileSize(filePath),
+			await this.stubPrivateFileMetadata(filePath, destinationFileName),
 			'private'
 		);
 
 		// TODO: Add interactive confirmation of AR price estimation
 
+		const fileDataRewardSettings = { reward: uploadBaseCosts.fileDataBaseReward, feeMultiple: this.feeMultiple };
+		const metadataRewardSettings = { reward: uploadBaseCosts.metaDataBaseReward, feeMultiple: this.feeMultiple };
 		const uploadFileResult = await this.arFsDao.uploadPrivateFile(
 			parentFolderId,
 			filePath,
 			password,
-			winstonPrice.toString(),
+			fileDataRewardSettings,
+			metadataRewardSettings,
 			destinationFileName
 		);
 
-		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(communityWinstonTip);
+		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(
+			uploadBaseCosts.communityWinstonTip
+		);
 
 		return Promise.resolve({
 			created: [
@@ -183,16 +223,19 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async createPublicFolder(folderName: string, driveId: string, parentFolderId?: FolderID): Promise<ArFSResult> {
-		// TODO: Assert that there's enough AR available in the wallet
+		// Assert that there's enough AR available in the wallet
+		const folderData = new ArFSPublicFolderTransactionData(folderName);
+		const { metaDataBaseReward } = await this.estimateAndAssertCostOfFolderUpload(folderData);
 
 		// Create the folder and retrieve its folder ID
-		const { folderTrxId, folderTrxReward, folderId } = await this.arFsDao.createPublicFolder(
-			folderName,
+		const { folderTrxId, folderTrxReward, folderId } = await this.arFsDao.createPublicFolder({
+			folderData,
 			driveId,
+			rewardSettings: { reward: metaDataBaseReward, feeMultiple: this.feeMultiple },
 			parentFolderId
-		);
+		});
 
-		// IN THE FUTURE WE'LL SEND A COMMUNITY TIP HERE
+		// IN THE FUTURE WE MIGHT SEND A COMMUNITY TIP HERE
 		return Promise.resolve({
 			created: [
 				{
@@ -209,8 +252,24 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async createPublicDrive(driveName: string): Promise<ArFSResult> {
-		// TODO: Assert that there's enough AR available in the wallet
-		const createDriveResult = await this.arFsDao.createPublicDrive(driveName);
+		// Assert that there's enough AR available in the wallet
+		// Use stub data to estimate costs since actual data requires entity IDs generated by ArFSDao
+		const stubRootFolderData = new ArFSPublicFolderTransactionData(driveName);
+		const stubDriveData = new ArFSPublicDriveTransactionData(driveName, stubEntityID);
+		const driveUploadCosts = await this.estimateAndAssertCostOfDriveCreation(stubDriveData, stubRootFolderData);
+		const driveRewardSettings = {
+			reward: driveUploadCosts.driveMetaDataBaseReward,
+			feeMultiple: this.feeMultiple
+		};
+		const rootFolderRewardSettings = {
+			reward: driveUploadCosts.rootFolderMetaDataBaseReward,
+			feeMultiple: this.feeMultiple
+		};
+		const createDriveResult = await this.arFsDao.createPublicDrive(
+			driveName,
+			driveRewardSettings,
+			rootFolderRewardSettings
+		);
 		return Promise.resolve({
 			created: [
 				{
@@ -233,11 +292,39 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async createPrivateDrive(driveName: string, password: string): Promise<ArFSResult> {
-		// TODO: Assert that there's enough AR available in the wallet
-		// Generate a new drive ID
-		const createDriveResult = await this.arFsDao.createPrivateDrive(driveName, password);
+		// Assert that there's enough AR available in the wallet
+		const wallet = this.wallet as JWKWallet;
+		const privKey = wallet.getPrivateKey();
+		const stubRootFolderData = await ArFSPrivateFolderTransactionData.from(
+			driveName,
+			stubEntityID,
+			password,
+			privKey
+		);
+		const stubDriveData = await ArFSPrivateDriveTransactionData.from(
+			driveName,
+			stubEntityID,
+			stubEntityID,
+			password,
+			privKey
+		);
+		const driveCreationCosts = await this.estimateAndAssertCostOfDriveCreation(stubDriveData, stubRootFolderData);
+		const driveRewardSettings = {
+			reward: driveCreationCosts.driveMetaDataBaseReward,
+			feeMultiple: this.feeMultiple
+		};
+		const rootFolderRewardSettings = {
+			reward: driveCreationCosts.rootFolderMetaDataBaseReward,
+			feeMultiple: this.feeMultiple
+		};
+		const createDriveResult = await this.arFsDao.createPrivateDrive(
+			driveName,
+			password,
+			driveRewardSettings,
+			rootFolderRewardSettings
+		);
 
-		// IN THE FUTURE WE'LL SEND A COMMUNITY TIP HERE
+		// IN THE FUTURE WE MIGHT SEND A COMMUNITY TIP HERE
 		return Promise.resolve({
 			created: [
 				{
@@ -266,28 +353,130 @@ export class ArDrive extends ArDriveAnonymous {
 		return Promise.resolve(driveEntity);
 	}
 
-	async estimateAndAssertCostOfUploadSize(fileSize: number, drivePrivacy: DrivePrivacy): Promise<FileUploadCosts> {
-		if (fileSize < 1) {
+	async estimateAndAssertCostOfFileUpload(
+		decryptedFileSize: number,
+		metaData: ArFSObjectTransactionData,
+		drivePrivacy: DrivePrivacy
+	): Promise<FileUploadBaseCosts> {
+		if (decryptedFileSize < 0) {
 			throw new Error('File size should be non-negative number!');
 		}
 
+		let fileSize = decryptedFileSize;
 		if (drivePrivacy === 'private') {
 			fileSize = this.encryptedDataSize(fileSize);
 		}
 
-		// TODO: Consider metadata JSON size
-		const totalSize = fileSize;
+		let totalPrice = 0;
+		let fileDataBaseReward = 0;
+		let communityWinstonTip = '0';
+		if (fileSize) {
+			fileDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(fileSize);
+			communityWinstonTip = await this.communityOracle.getCommunityWinstonTip(fileDataBaseReward.toString());
+			const tipReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(0);
+			totalPrice += fileDataBaseReward;
+			totalPrice += +communityWinstonTip;
+			totalPrice += tipReward;
+		}
+		const metaDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(metaData.sizeOf());
+		totalPrice += metaDataBaseReward;
 
-		const winstonPrice = await this.priceEstimator.getBaseWinstonPriceForByteCount(totalSize);
+		const totalWinstonPrice = totalPrice.toString();
 
-		// TODO: Consider tip reward via oracle that issues request to https://arweave.net/price/0/{target}
-		const communityWinstonTip = await this.communityOracle.getCommunityWinstonTip(winstonPrice.toString());
-		const totalWinstonPrice = (+winstonPrice + +communityWinstonTip).toString();
-
+		const walletBalance = this.walletDao.getWalletWinstonBalance(this.wallet);
 		if (!this.walletDao.walletHasBalance(this.wallet, totalWinstonPrice)) {
-			throw new Error(`Not enough AR for data upload of size ${totalSize} bytes!`);
+			throw new Error(
+				`Wallet balance of ${walletBalance} Winston is not enough (${totalWinstonPrice}) for data upload of size ${fileSize} bytes!`
+			);
 		}
 
-		return { winstonPrice: winstonPrice.toString(), communityWinstonTip };
+		return {
+			fileDataBaseReward: fileDataBaseReward.toString(),
+			metaDataBaseReward: metaDataBaseReward.toString(),
+			communityWinstonTip
+		};
+	}
+
+	async estimateAndAssertCostOfFolderUpload(metaData: ArFSObjectTransactionData): Promise<FolderUploadBaseCosts> {
+		const metaDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(metaData.sizeOf());
+		const totalWinstonPrice = metaDataBaseReward.toString();
+
+		const walletBalance = this.walletDao.getWalletWinstonBalance(this.wallet);
+		if (!this.walletDao.walletHasBalance(this.wallet, totalWinstonPrice)) {
+			throw new Error(
+				`Wallet balance of ${walletBalance} Winston is not enough (${totalWinstonPrice}) for folder creation!`
+			);
+		}
+
+		return {
+			metaDataBaseReward: totalWinstonPrice
+		};
+	}
+
+	async estimateAndAssertCostOfDriveCreation(
+		driveMetaData: ArFSDriveTransactionData,
+		rootFolderMetaData: ArFSFolderTransactionData
+	): Promise<DriveUploadBaseCosts> {
+		let totalPrice = 0;
+		const driveMetaDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(
+			driveMetaData.sizeOf()
+		);
+		totalPrice += driveMetaDataBaseReward;
+		const rootFolderMetaDataBaseReward = await this.priceEstimator.getBaseWinstonPriceForByteCount(
+			rootFolderMetaData.sizeOf()
+		);
+		totalPrice += rootFolderMetaDataBaseReward;
+
+		const totalWinstonPrice = totalPrice.toString();
+
+		if (!this.walletDao.walletHasBalance(this.wallet, totalWinstonPrice)) {
+			const walletBalance = this.walletDao.getWalletWinstonBalance(this.wallet);
+			throw new Error(
+				`Wallet balance of ${walletBalance} Winston is not enough (${totalPrice}) for drive creation!`
+			);
+		}
+
+		return {
+			driveMetaDataBaseReward: driveMetaDataBaseReward.toString(),
+			rootFolderMetaDataBaseReward: rootFolderMetaDataBaseReward.toString()
+		};
+	}
+
+	// Provides for stubbing metadata during cost estimations since the data trx ID won't yet be known
+	private stubPublicFileMetadata(
+		filePath: string,
+		destinationFileName?: string
+	): ArFSPublicFileMetadataTransactionData {
+		const fileStats = fs.statSync(filePath);
+		const dataContentType = extToMime(filePath);
+		const lastModifiedDateMS = Math.floor(fileStats.mtimeMs);
+		return new ArFSPublicFileMetadataTransactionData(
+			destinationFileName ?? basename(filePath),
+			fileStats.size,
+			lastModifiedDateMS,
+			stubTransactionID,
+			dataContentType
+		);
+	}
+
+	// Provides for stubbing metadata during cost estimations since the data trx and File IDs won't yet be known
+	private async stubPrivateFileMetadata(
+		filePath: string,
+		destinationFileName?: string
+	): Promise<ArFSPrivateFileMetadataTransactionData> {
+		const fileStats = fs.statSync(filePath);
+		const dataContentType = extToMime(filePath);
+		const lastModifiedDateMS = Math.floor(fileStats.mtimeMs);
+		return await ArFSPrivateFileMetadataTransactionData.from(
+			destinationFileName ?? basename(filePath),
+			fileStats.size,
+			lastModifiedDateMS,
+			stubTransactionID,
+			dataContentType,
+			stubEntityID,
+			stubEntityID,
+			'stubPassword',
+			(this.wallet as JWKWallet).getPrivateKey()
+		);
 	}
 }

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -132,9 +132,8 @@ export class ArDrive extends ArDriveAnonymous {
 		});
 	}
 
-	/** Estimates the size of a private file encrypted with a uuid */
+	/** Computes the size of a private file encrypted with AES256-GCM */
 	encryptedFileSize(filePath: string): number {
-		// cipherLen = (clearLen/16 + 1) * 16;
 		return (this.getFileSize(filePath) / 16 + 1) * 16;
 	}
 

--- a/src/arfs_trx_data_types.ts
+++ b/src/arfs_trx_data_types.ts
@@ -17,6 +17,7 @@ export interface ArFSObjectTransactionData {
 
 export abstract class ArFSDriveTransactionData implements ArFSObjectTransactionData {
 	abstract asTransactionData(): string | Buffer;
+	// TODO: Share repeated sizeOf() function to all classes
 	sizeOf(): number {
 		return this.asTransactionData().length;
 	}

--- a/src/arfs_trx_data_types.ts
+++ b/src/arfs_trx_data_types.ts
@@ -186,7 +186,7 @@ export class ArFSPrivateFileMetadataTransactionData extends ArFSFileMetadataTran
 				})
 			)
 		);
-		return new ArFSPrivateFileMetadataTransactionData(cipher, cipherIV, fileKey, data);
+		return new ArFSPrivateFileMetadataTransactionData(cipher, cipherIV, data, fileKey);
 	}
 
 	asTransactionData(): Buffer {

--- a/src/arfs_trx_data_types.ts
+++ b/src/arfs_trx_data_types.ts
@@ -8,14 +8,18 @@ import {
 	fileEncrypt,
 	JWKInterface
 } from 'ardrive-core-js';
-import { CipherIV, DataContentType, DriveID, DriveKey, FileID, FolderID, TransactionID } from './types';
+import { CipherIV, DataContentType, DriveID, DriveKey, FileID, FileKey, FolderID, TransactionID } from './types';
 
 export interface ArFSObjectTransactionData {
 	asTransactionData(): string | Buffer;
+	sizeOf(): number;
 }
 
 export abstract class ArFSDriveTransactionData implements ArFSObjectTransactionData {
 	abstract asTransactionData(): string | Buffer;
+	sizeOf(): number {
+		return this.asTransactionData().length;
+	}
 }
 
 export class ArFSPublicDriveTransactionData extends ArFSDriveTransactionData {
@@ -68,6 +72,9 @@ export class ArFSPrivateDriveTransactionData extends ArFSDriveTransactionData {
 
 export abstract class ArFSFolderTransactionData implements ArFSObjectTransactionData {
 	abstract asTransactionData(): string | Buffer;
+	sizeOf(): number {
+		return this.asTransactionData().length;
+	}
 }
 
 export class ArFSPublicFolderTransactionData extends ArFSFolderTransactionData {
@@ -116,6 +123,9 @@ export class ArFSPrivateFolderTransactionData extends ArFSFolderTransactionData 
 
 export abstract class ArFSFileMetadataTransactionData implements ArFSObjectTransactionData {
 	abstract asTransactionData(): string | Buffer;
+	sizeOf(): number {
+		return this.asTransactionData().length;
+	}
 }
 
 export class ArFSPublicFileMetadataTransactionData extends ArFSFileMetadataTransactionData {
@@ -145,6 +155,7 @@ export class ArFSPrivateFileMetadataTransactionData extends ArFSFileMetadataTran
 		readonly cipher: CipherType,
 		readonly cipherIV: CipherIV,
 		readonly encryptedFileMetadata: Buffer,
+		readonly fileKey: FileKey,
 		readonly driveAuthMode: DriveAuthMode = 'password'
 	) {
 		super();
@@ -175,7 +186,7 @@ export class ArFSPrivateFileMetadataTransactionData extends ArFSFileMetadataTran
 				})
 			)
 		);
-		return new ArFSPrivateFileMetadataTransactionData(cipher, cipherIV, data);
+		return new ArFSPrivateFileMetadataTransactionData(cipher, cipherIV, fileKey, data);
 	}
 
 	asTransactionData(): Buffer {
@@ -185,6 +196,9 @@ export class ArFSPrivateFileMetadataTransactionData extends ArFSFileMetadataTran
 
 export abstract class ArFSFileDataTransactionData implements ArFSObjectTransactionData {
 	abstract asTransactionData(): string | Buffer;
+	sizeOf(): number {
+		return this.asTransactionData().length;
+	}
 }
 export class ArFSPublicFileDataTransactionData extends ArFSFileDataTransactionData {
 	constructor(private readonly fileData: Buffer) {

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -9,7 +9,6 @@ import {
 	ArFSEntity,
 	ContentType,
 	deriveDriveKey,
-	deriveFileKey,
 	driveDecrypt,
 	DrivePrivacy,
 	EntityType,
@@ -51,7 +50,8 @@ import {
 	FileKey,
 	DEFAULT_APP_NAME,
 	DEFAULT_APP_VERSION,
-	CURRENT_ARFS_VERSION
+	CURRENT_ARFS_VERSION,
+	RewardSettings
 } from './types';
 import { CreateTransactionInterface } from 'arweave/node/common';
 
@@ -91,6 +91,14 @@ export abstract class ArFSDAOType {
 	protected abstract readonly arweave: Arweave;
 	protected abstract readonly appName: string;
 	protected abstract readonly appVersion: string;
+}
+
+export interface CreatePublicFolderSettings {
+	folderData: ArFSPublicFolderTransactionData;
+	driveId: DriveID;
+	rewardSettings: RewardSettings;
+	parentFolderId?: FolderID;
+	syncParentFolderId?: boolean;
 }
 
 /**
@@ -209,12 +217,13 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		super(arweave, appName, appVersion);
 	}
 
-	async createPublicFolder(
-		folderName: string,
-		driveId: DriveID,
-		parentFolderId?: FolderID,
+	async createPublicFolder({
+		folderData,
+		driveId,
+		rewardSettings,
+		parentFolderId,
 		syncParentFolderId = true
-	): Promise<ArFSCreateFolderResult> {
+	}: CreatePublicFolderSettings): Promise<ArFSCreateFolderResult> {
 		if (parentFolderId) {
 			// Assert that drive ID is consistent with parent folder ID
 			const actualDriveId = await this.getDriveIdForFolderId(parentFolderId);
@@ -244,13 +253,13 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 		// Create a root folder metadata transaction
 		const folderMetadata = new ArFSPublicFolderMetaDataPrototype(
-			new ArFSPublicFolderTransactionData(folderName),
+			folderData,
 			unixTime,
 			driveId,
 			folderId,
 			parentFolderId
 		);
-		const folderTrx = await this.prepareArFSObjectTransaction(folderMetadata);
+		const folderTrx = await this.prepareArFSObjectTransaction(folderMetadata, rewardSettings);
 
 		// Create the Folder Uploader objects
 		const folderUploader = await this.arweave.transactions.getUploader(folderTrx);
@@ -263,16 +272,26 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return { folderTrxId: folderTrx.id, folderTrxReward: folderTrx.reward, folderId };
 	}
 
-	async createPublicDrive(driveName: string): Promise<ArFSCreateDriveResult> {
+	async createPublicDrive(
+		driveName: string,
+		driveRewardSettings: RewardSettings,
+		rootFolderRewardSettings: RewardSettings
+	): Promise<ArFSCreateDriveResult> {
 		// Generate a new drive ID  for the new drive
 		const driveId = uuidv4();
 
 		// Create root folder
+		const folderData = new ArFSPublicFolderTransactionData(driveName);
 		const {
 			folderTrxId: rootFolderTrxId,
 			folderTrxReward: rootFolderTrxReward,
 			folderId: rootFolderId
-		} = await this.createPublicFolder(driveName, driveId, undefined, false);
+		} = await this.createPublicFolder({
+			folderData,
+			driveId,
+			rewardSettings: rootFolderRewardSettings,
+			syncParentFolderId: false
+		});
 
 		// Get the current time so the app can display the "created" data later on
 		const unixTime = Math.round(Date.now() / 1000);
@@ -283,7 +302,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			unixTime,
 			driveId
 		);
-		const driveTrx = await this.prepareArFSObjectTransaction(driveMetaData);
+		const driveTrx = await this.prepareArFSObjectTransaction(driveMetaData, driveRewardSettings);
 
 		// Create the Drive and Folder Uploader objects
 		const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
@@ -303,7 +322,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		};
 	}
 
-	async createPrivateDrive(driveName: string, password: string): Promise<ArFSCreatePrivateDriveResult> {
+	async createPrivateDrive(
+		driveName: string,
+		password: string,
+		driveRewardSettings: RewardSettings,
+		rootFolderRewardSettings: RewardSettings
+	): Promise<ArFSCreatePrivateDriveResult> {
 		// Generate a new drive ID  for the new drive
 		const driveId = uuidv4();
 
@@ -325,7 +349,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 		// Create a drive metadata transaction
 		const driveMetaData = new ArFSPrivateDriveMetaDataPrototype(unixTime, driveId, privateDriveData);
-		const driveTrx = await this.prepareArFSObjectTransaction(driveMetaData);
+		const driveTrx = await this.prepareArFSObjectTransaction(driveMetaData, driveRewardSettings);
 
 		// Create a root folder metadata transaction
 		const rootFolderMetadata = new ArFSPrivateFolderMetaDataPrototype(
@@ -334,7 +358,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			rootFolderId,
 			await ArFSPrivateFolderTransactionData.from(driveName, driveId, password, wallet.getPrivateKey())
 		);
-		const rootFolderTrx = await this.prepareArFSObjectTransaction(rootFolderMetadata);
+		const rootFolderTrx = await this.prepareArFSObjectTransaction(rootFolderMetadata, rootFolderRewardSettings);
 
 		// Create the Drive and Folder Uploader objects
 		const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
@@ -364,7 +388,8 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	async uploadPublicFile(
 		parentFolderId: FolderID,
 		filePath: string,
-		reward: Winston,
+		fileDataRewardSettings: RewardSettings,
+		metadataRewardSettings: RewardSettings,
 		destFileName?: string
 	): Promise<ArFSUploadFileResult> {
 		// Retrieve drive ID from folder ID and ensure that it is indeed public
@@ -394,7 +419,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			new ArFSPublicFileDataTransactionData(fileData),
 			dataContentType
 		);
-		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, reward);
+		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, fileDataRewardSettings);
 
 		// Upload file data
 		const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
@@ -416,7 +441,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			fileId,
 			parentFolderId
 		);
-		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadata);
+		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadata, metadataRewardSettings);
 
 		// Upload meta data
 		const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
@@ -437,7 +462,8 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		parentFolderId: FolderID,
 		filePath: string,
 		password: string,
-		reward: Winston,
+		fileDataRewardSettings: RewardSettings,
+		metadataRewardSettings: RewardSettings,
 		destFileName?: string
 	): Promise<ArFSUploadPrivateFileResult> {
 		const wallet: JWKWallet = this.wallet as JWKWallet;
@@ -468,7 +494,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		const fileDataPrototype = new ArFSPrivateFileDataPrototype(
 			await ArFSPrivateFileDataTransactionData.from(fileData, fileId, driveId, password, wallet.getPrivateKey())
 		);
-		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, reward);
+		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, fileDataRewardSettings);
 
 		// Upload file data
 		const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
@@ -477,24 +503,26 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		}
 
 		// Prepare meta data transaction
-		const fileMetadata = new ArFSPrivateFileMetaDataPrototype(
-			await ArFSPrivateFileMetadataTransactionData.from(
-				destinationFileName,
-				fileStats.size,
-				lastModifiedDateMS,
-				dataTrx.id,
-				dataContentType,
-				fileId,
-				driveId,
-				password,
-				wallet.getPrivateKey()
-			),
+		const fileMetaData = await ArFSPrivateFileMetadataTransactionData.from(
+			destinationFileName,
+			fileStats.size,
+			lastModifiedDateMS,
+			dataTrx.id,
+			dataContentType,
+			fileId,
+			driveId,
+			password,
+			wallet.getPrivateKey()
+		);
+		const fileMetadataPrototype = new ArFSPrivateFileMetaDataPrototype(
+			fileMetaData,
 			unixTime,
 			driveId,
 			fileId,
 			parentFolderId
 		);
-		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadata);
+
+		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadataPrototype, metadataRewardSettings);
 
 		// Upload meta data
 		const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
@@ -502,23 +530,19 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			await metaDataUploader.uploadChunk();
 		}
 
-		// TODO: Get fileKey from ArFSPrivateFileMetadataTransactionData somehow
 		return {
 			dataTrxId: dataTrx.id,
 			dataTrxReward: dataTrx.reward,
 			metaDataTrxId: metaDataTrx.id,
 			metaDataTrxReward: metaDataTrx.reward,
 			fileId,
-			fileKey: await deriveFileKey(
-				fileId,
-				await deriveDriveKey(password, driveId, JSON.stringify(wallet.getPrivateKey()))
-			)
+			fileKey: fileMetaData.fileKey
 		};
 	}
 
 	async prepareArFSObjectTransaction(
 		objectMetaData: ArFSObjectMetadataPrototype,
-		reward?: Winston,
+		rewardSettings: RewardSettings = {},
 		otherTags: GQLTagInterface[] = []
 	): Promise<Transaction> {
 		const wallet = this.wallet as JWKWallet;
@@ -529,15 +553,24 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		};
 
 		// If we provided our own reward setting, use it now
-		if (reward) {
-			trxAttributes.reward = reward;
+		if (rewardSettings.reward) {
+			trxAttributes.reward = rewardSettings.reward;
 		}
 		const transaction = await this.arweave.createTransaction(trxAttributes, wallet.getPrivateKey());
+
+		// If we've opted to boost the transaction, do so now
+		if (rewardSettings.feeMultiple && rewardSettings.feeMultiple > 1.0) {
+			// Round up with ceil because fractional Winston will cause an Arweave API failure
+			transaction.reward = Math.ceil(+transaction.reward * rewardSettings.feeMultiple).toString();
+		}
 
 		// Add baseline ArFS Tags
 		transaction.addTag('App-Name', this.appName);
 		transaction.addTag('App-Version', this.appVersion);
 		transaction.addTag('ArFS', CURRENT_ARFS_VERSION);
+		if (rewardSettings.feeMultiple && rewardSettings.feeMultiple > 1.0) {
+			transaction.addTag('Boost', rewardSettings.feeMultiple.toString());
+		}
 
 		// Add object-specific tags
 		objectMetaData.addTagsToTransaction(transaction);

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -211,6 +211,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	constructor(
 		private readonly wallet: Wallet,
 		arweave: Arweave,
+		private readonly dryRun = false,
 		protected appName = DEFAULT_APP_NAME,
 		protected appVersion = DEFAULT_APP_VERSION
 	) {
@@ -261,12 +262,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		);
 		const folderTrx = await this.prepareArFSObjectTransaction(folderMetadata, rewardSettings);
 
-		// Create the Folder Uploader objects
-		const folderUploader = await this.arweave.transactions.getUploader(folderTrx);
-
-		// Execute the uploads
-		while (!folderUploader.isComplete) {
-			await folderUploader.uploadChunk();
+		// Execute the upload
+		if (!this.dryRun) {
+			const folderUploader = await this.arweave.transactions.getUploader(folderTrx);
+			while (!folderUploader.isComplete) {
+				await folderUploader.uploadChunk();
+			}
 		}
 
 		return { folderTrxId: folderTrx.id, folderTrxReward: folderTrx.reward, folderId };
@@ -304,12 +305,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		);
 		const driveTrx = await this.prepareArFSObjectTransaction(driveMetaData, driveRewardSettings);
 
-		// Create the Drive and Folder Uploader objects
-		const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
-
-		// Execute the uploads
-		while (!driveUploader.isComplete) {
-			await driveUploader.uploadChunk();
+		// Execute the upload
+		if (!this.dryRun) {
+			const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
+			while (!driveUploader.isComplete) {
+				await driveUploader.uploadChunk();
+			}
 		}
 
 		return {
@@ -360,16 +361,16 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		);
 		const rootFolderTrx = await this.prepareArFSObjectTransaction(rootFolderMetadata, rootFolderRewardSettings);
 
-		// Create the Drive and Folder Uploader objects
-		const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
-		const folderUploader = await this.arweave.transactions.getUploader(rootFolderTrx);
-
 		// Execute the uploads
-		while (!driveUploader.isComplete) {
-			await driveUploader.uploadChunk();
-		}
-		while (!folderUploader.isComplete) {
-			await folderUploader.uploadChunk();
+		if (!this.dryRun) {
+			const driveUploader = await this.arweave.transactions.getUploader(driveTrx);
+			const folderUploader = await this.arweave.transactions.getUploader(rootFolderTrx);
+			while (!driveUploader.isComplete) {
+				await driveUploader.uploadChunk();
+			}
+			while (!folderUploader.isComplete) {
+				await folderUploader.uploadChunk();
+			}
 		}
 
 		const driveKey = privateDriveData.driveKey;
@@ -422,9 +423,11 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, fileDataRewardSettings);
 
 		// Upload file data
-		const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
-		while (!dataUploader.isComplete) {
-			await dataUploader.uploadChunk();
+		if (!this.dryRun) {
+			const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
+			while (!dataUploader.isComplete) {
+				await dataUploader.uploadChunk();
+			}
 		}
 
 		// Prepare meta data transaction
@@ -444,9 +447,11 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadata, metadataRewardSettings);
 
 		// Upload meta data
-		const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
-		while (!metaDataUploader.isComplete) {
-			await metaDataUploader.uploadChunk();
+		if (!this.dryRun) {
+			const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
+			while (!metaDataUploader.isComplete) {
+				await metaDataUploader.uploadChunk();
+			}
 		}
 
 		return {
@@ -497,9 +502,11 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		const dataTrx = await this.prepareArFSObjectTransaction(fileDataPrototype, fileDataRewardSettings);
 
 		// Upload file data
-		const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
-		while (!dataUploader.isComplete) {
-			await dataUploader.uploadChunk();
+		if (!this.dryRun) {
+			const dataUploader = await this.arweave.transactions.getUploader(dataTrx);
+			while (!dataUploader.isComplete) {
+				await dataUploader.uploadChunk();
+			}
 		}
 
 		// Prepare meta data transaction
@@ -525,9 +532,11 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		const metaDataTrx = await this.prepareArFSObjectTransaction(fileMetadataPrototype, metadataRewardSettings);
 
 		// Upload meta data
-		const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
-		while (!metaDataUploader.isComplete) {
-			await metaDataUploader.uploadChunk();
+		if (!this.dryRun) {
+			const metaDataUploader = await this.arweave.transactions.getUploader(metaDataTrx);
+			while (!metaDataUploader.isComplete) {
+				await metaDataUploader.uploadChunk();
+			}
 		}
 
 		return {

--- a/src/commands/create_drive.ts
+++ b/src/commands/create_drive.ts
@@ -4,6 +4,7 @@ import {
 	BoostParameter,
 	DriveNameParameter,
 	DrivePasswordParameter,
+	DryRunParameter,
 	SeedPhraseParameter,
 	WalletFileParameter
 } from '../parameter_declarations';
@@ -15,13 +16,21 @@ import { FeeMultiple } from '../types';
 
 new CLICommand({
 	name: 'create-drive',
-	parameters: [WalletFileParameter, SeedPhraseParameter, DriveNameParameter, DrivePasswordParameter, BoostParameter],
+	parameters: [
+		WalletFileParameter,
+		SeedPhraseParameter,
+		DriveNameParameter,
+		DrivePasswordParameter,
+		BoostParameter,
+		DryRunParameter
+	],
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet: Wallet = await context.getWallet();
 		const ardrive = arDriveFactory({
 			wallet: wallet,
-			feeMultiple: options.boost as FeeMultiple
+			feeMultiple: options.boost as FeeMultiple,
+			dryRun: options.dryRun
 		});
 		const createDriveResult = await (async function () {
 			if (await context.getIsPrivate()) {

--- a/src/commands/create_drive.ts
+++ b/src/commands/create_drive.ts
@@ -1,6 +1,7 @@
 import { CLICommand } from '../CLICommand';
 import { CommonContext } from '../CLICommand/common_context';
 import {
+	BoostParameter,
 	DriveNameParameter,
 	DrivePasswordParameter,
 	SeedPhraseParameter,
@@ -8,16 +9,20 @@ import {
 } from '../parameter_declarations';
 import { Wallet } from '../wallet_new';
 import { arDriveFactory, cliWalletDao } from '..';
+import { FeeMultiple } from '../types';
 
 /* eslint-disable no-console */
 
 new CLICommand({
 	name: 'create-drive',
-	parameters: [WalletFileParameter, SeedPhraseParameter, DriveNameParameter, DrivePasswordParameter],
+	parameters: [WalletFileParameter, SeedPhraseParameter, DriveNameParameter, DrivePasswordParameter, BoostParameter],
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet: Wallet = await context.getWallet();
-		const ardrive = arDriveFactory(wallet);
+		const ardrive = arDriveFactory({
+			wallet: wallet,
+			feeMultiple: options.boost as FeeMultiple
+		});
 		const createDriveResult = await (async function () {
 			if (await context.getIsPrivate()) {
 				return ardrive.createPrivateDrive(options.driveName, options.drivePassword);

--- a/src/commands/drive_info.ts
+++ b/src/commands/drive_info.ts
@@ -27,7 +27,9 @@ new CLICommand({
 		const wallet = await context.getWallet().catch(() => null);
 		const result = await (function () {
 			if (wallet) {
-				const arDrive = arDriveFactory(wallet);
+				const arDrive = arDriveFactory({
+					wallet: wallet
+				});
 				const driveId: string = options.driveId;
 				// const getAllRevisions: boolean = options.getAllRevisions;
 				return arDrive.getPrivateDrive(driveId, options.drivePassword /*, getAllRevisions*/);

--- a/src/commands/send_ar.ts
+++ b/src/commands/send_ar.ts
@@ -5,6 +5,7 @@ import {
 	ArAmountParameter,
 	BoostParameter,
 	DestinationAddressParameter,
+	DryRunParameter,
 	WalletFileParameter
 } from '../parameter_declarations';
 
@@ -12,7 +13,7 @@ import {
 
 new CLICommand({
 	name: 'send-ar',
-	parameters: [ArAmountParameter, DestinationAddressParameter, WalletFileParameter, BoostParameter],
+	parameters: [ArAmountParameter, DestinationAddressParameter, WalletFileParameter, BoostParameter, DryRunParameter],
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet = await context.getWallet();
@@ -26,6 +27,7 @@ new CLICommand({
 			wallet,
 			options.destAddress,
 			options.boost,
+			options.dryRun,
 			[
 				{ name: 'appName', value: 'ArDrive-CLI' },
 				{ name: 'appVersion', value: '2.0' },

--- a/src/commands/send_ar.ts
+++ b/src/commands/send_ar.ts
@@ -1,13 +1,18 @@
 import { cliWalletDao } from '..';
 import { CLICommand } from '../CLICommand';
 import { CommonContext } from '../CLICommand/common_context';
-import { ArAmountParameter, DestinationAddressParameter, WalletFileParameter } from '../parameter_declarations';
+import {
+	ArAmountParameter,
+	BoostParameter,
+	DestinationAddressParameter,
+	WalletFileParameter
+} from '../parameter_declarations';
 
 /* eslint-disable no-console */
 
 new CLICommand({
 	name: 'send-ar',
-	parameters: [ArAmountParameter, DestinationAddressParameter, WalletFileParameter],
+	parameters: [ArAmountParameter, DestinationAddressParameter, WalletFileParameter, BoostParameter],
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet = await context.getWallet();
@@ -16,11 +21,17 @@ new CLICommand({
 		console.log(`arAmount: ${options.arAmount}`);
 		console.log(`destAddress: ${options.destAddress}`);
 		console.log(await cliWalletDao.getAddressWinstonBalance(options.destAddress));
-		const arTransferResult = await cliWalletDao.sendARToAddress(+options.arAmount, wallet, options.destAddress, [
-			{ name: 'appName', value: 'ArDrive-CLI' },
-			{ name: 'appVersion', value: '2.0' },
-			{ name: 'trxType', value: 'transfer' }
-		]);
+		const arTransferResult = await cliWalletDao.sendARToAddress(
+			+options.arAmount,
+			wallet,
+			options.destAddress,
+			options.boost,
+			[
+				{ name: 'appName', value: 'ArDrive-CLI' },
+				{ name: 'appVersion', value: '2.0' },
+				{ name: 'trxType', value: 'transfer' }
+			]
+		);
 
 		console.log(JSON.stringify(arTransferResult, null, 4));
 		process.exit(0);

--- a/src/commands/upload_file.ts
+++ b/src/commands/upload_file.ts
@@ -6,6 +6,7 @@ import {
 	DestinationFileNameParameter,
 	DriveKeyParameter,
 	DrivePasswordParameter,
+	DryRunParameter,
 	LocalFilePathParameter,
 	LocalFilesParameter,
 	ParentFolderIdParameter,
@@ -37,7 +38,8 @@ new CLICommand({
 		DrivePasswordParameter,
 		DriveKeyParameter,
 		WalletFileParameter,
-		BoostParameter
+		BoostParameter,
+		DryRunParameter
 	],
 	async action(options) {
 		const filesToUpload: UploadFileParameter[] = (function (): UploadFileParameter[] {
@@ -92,7 +94,8 @@ new CLICommand({
 			const arDrive = arDriveFactory({
 				wallet: wallet,
 				priceEstimator: priceEstimator,
-				feeMultiple: options.boost as FeeMultiple
+				feeMultiple: options.boost as FeeMultiple,
+				dryRun: options.dryRun
 			});
 			await Promise.all(
 				filesToUpload.map(async (fileToUpload) => {

--- a/src/commands/upload_file.ts
+++ b/src/commands/upload_file.ts
@@ -2,6 +2,7 @@ import { GatewayOracle } from 'ardrive-core-js';
 import { arDriveFactory } from '..';
 import { CLICommand } from '../CLICommand';
 import {
+	BoostParameter,
 	DestinationFileNameParameter,
 	DriveKeyParameter,
 	DrivePasswordParameter,
@@ -10,6 +11,7 @@ import {
 	ParentFolderIdParameter,
 	WalletFileParameter
 } from '../parameter_declarations';
+import { FeeMultiple } from '../types';
 import { readJWKFile } from '../utils';
 import { ARDataPriceEstimator } from '../utils/ar_data_price_estimator';
 import { ARDataPriceOracleEstimator } from '../utils/ar_data_price_oracle_estimator';
@@ -34,7 +36,8 @@ new CLICommand({
 		LocalFilesParameter,
 		DrivePasswordParameter,
 		DriveKeyParameter,
-		WalletFileParameter
+		WalletFileParameter,
+		BoostParameter
 	],
 	async action(options) {
 		const filesToUpload: UploadFileParameter[] = (function (): UploadFileParameter[] {
@@ -86,7 +89,11 @@ new CLICommand({
 				}
 			})();
 
-			const arDrive = arDriveFactory(wallet, priceEstimator);
+			const arDrive = arDriveFactory({
+				wallet: wallet,
+				priceEstimator: priceEstimator,
+				feeMultiple: options.boost as FeeMultiple
+			});
 			await Promise.all(
 				filesToUpload.map(async (fileToUpload) => {
 					if (!fileToUpload.parentFolderId || !fileToUpload.localFilePath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ArDrive } from './ardrive';
 import { ArFSDAO } from './arfsdao';
 import { ARDataPriceRegressionEstimator } from './utils/ar_data_price_regression_estimator';
 import { ARDataPriceEstimator } from './utils/ar_data_price_estimator';
+import { FeeMultiple } from './types';
 
 if (require.main === module) {
 	// declare all parameters
@@ -30,12 +31,21 @@ export const cliArweave = Arweave.init({
 
 export const cliWalletDao = new WalletDAO(cliArweave, CLI_APP_NAME, CLI_APP_VERSION);
 
-export function arDriveFactory(
-	wallet: Wallet,
-	priceEstimator: ARDataPriceEstimator = new ARDataPriceRegressionEstimator(),
-	walletDao: WalletDAO = cliWalletDao,
-	arweave: Arweave = cliArweave
-): ArDrive {
+export interface ArDriveSettings {
+	wallet: Wallet;
+	priceEstimator?: ARDataPriceEstimator;
+	walletDao?: WalletDAO;
+	arweave?: Arweave;
+	feeMultiple?: FeeMultiple;
+}
+
+export function arDriveFactory({
+	wallet,
+	priceEstimator = new ARDataPriceRegressionEstimator(),
+	walletDao = cliWalletDao,
+	arweave = cliArweave,
+	feeMultiple
+}: ArDriveSettings): ArDrive {
 	return new ArDrive(
 		wallet,
 		walletDao,
@@ -43,6 +53,7 @@ export function arDriveFactory(
 		new ArDriveCommunityOracle(arweave),
 		CLI_APP_NAME,
 		CLI_APP_VERSION,
-		priceEstimator
+		priceEstimator,
+		feeMultiple
 	);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export interface ArDriveSettings {
 	walletDao?: WalletDAO;
 	arweave?: Arweave;
 	feeMultiple?: FeeMultiple;
+	dryRun?: boolean;
 }
 
 export function arDriveFactory({
@@ -44,16 +45,18 @@ export function arDriveFactory({
 	priceEstimator = new ARDataPriceRegressionEstimator(),
 	walletDao = cliWalletDao,
 	arweave = cliArweave,
-	feeMultiple
+	feeMultiple,
+	dryRun = false
 }: ArDriveSettings): ArDrive {
 	return new ArDrive(
 		wallet,
 		walletDao,
-		new ArFSDAO(wallet, arweave, CLI_APP_NAME, CLI_APP_VERSION),
+		new ArFSDAO(wallet, arweave, dryRun, CLI_APP_NAME, CLI_APP_VERSION),
 		new ArDriveCommunityOracle(arweave),
 		CLI_APP_NAME,
 		CLI_APP_VERSION,
 		priceEstimator,
-		feeMultiple
+		feeMultiple,
+		dryRun
 	);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export function arDriveFactory(
 	return new ArDrive(
 		wallet,
 		walletDao,
-		new ArFSDAO(wallet, arweave),
+		new ArFSDAO(wallet, arweave, CLI_APP_NAME, CLI_APP_VERSION),
 		new ArDriveCommunityOracle(arweave),
 		CLI_APP_NAME,
 		CLI_APP_VERSION,

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -16,6 +16,7 @@ export const LocalFilePathParameter = 'localFilePath';
 export const DestinationFileNameParameter = 'destFileName';
 export const LocalFilesParameter = 'localFiles';
 export const GetAllRevisionsParameter = 'getAllRevisions';
+export const BoostParameter = 'boost';
 
 /**
  * Note: importing this file will declare all the above parameters
@@ -135,4 +136,11 @@ Parameter.declare({
 	aliases: ['--get-all-revisions'],
 	description: '(OPTIONAL) gets every revision',
 	type: 'boolean'
+});
+
+Parameter.declare({
+	name: BoostParameter,
+	aliases: ['--boost'],
+	description:
+		'(OPTIONAL) a multiple of the base transaction data fee that can be used to accelerate transaction mining. A multiple of 2.5 would boost a 100 Winston transaction fee to 250 Winston.'
 });

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -17,6 +17,7 @@ export const DestinationFileNameParameter = 'destFileName';
 export const LocalFilesParameter = 'localFiles';
 export const GetAllRevisionsParameter = 'getAllRevisions';
 export const BoostParameter = 'boost';
+export const DryRunParameter = 'dryRun';
 
 /**
  * Note: importing this file will declare all the above parameters
@@ -143,4 +144,12 @@ Parameter.declare({
 	aliases: ['--boost'],
 	description:
 		'(OPTIONAL) a multiple of the base transaction data fee that can be used to accelerate transaction mining. A multiple of 2.5 would boost a 100 Winston transaction fee to 250 Winston.'
+});
+
+Parameter.declare({
+	name: DryRunParameter,
+	aliases: ['--dry-run'],
+	description:
+		'(OPTIONAL) Print the results of the transactions that would occur, and their potential fees, without sending the transactions.',
+	type: 'boolean'
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,9 @@ export interface ArDriveCommunityTip {
 }
 
 export type TipType = 'data upload';
+
+export type FeeMultiple = number; // TODO: assert always >= 1.0
+export type RewardSettings = {
+	reward?: Winston;
+	feeMultiple?: FeeMultiple;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,10 @@ export async function fetchMempool(): Promise<string[]> {
 	return response.json();
 }
 
+export function urlEncodeHashKey(keyBuffer: Buffer) {
+	return keyBuffer.toString('base64').replace('=', '');
+}
+
 export function showHelp(): void {
 	console.log(`
 Usage: <this script> <action> <options>

--- a/src/wallet_new.ts
+++ b/src/wallet_new.ts
@@ -97,6 +97,7 @@ export class WalletDAO {
 		fromWallet: Wallet,
 		toAddress: ArweaveAddress,
 		rewardSettings: RewardSettings = {},
+		dryRun = false,
 		[
 			{ value: appName = this.appName },
 			{ value: appVersion = this.appVersion },
@@ -138,7 +139,13 @@ export class WalletDAO {
 		await this.arweave.transactions.sign(transaction, jwkWallet.getPrivateKey());
 
 		// Submit the transaction
-		const response = await this.arweave.transactions.post(transaction);
+		const response = await (async () => {
+			if (dryRun) {
+				return { status: 200, statusText: 'OK', data: '' };
+			} else {
+				return this.arweave.transactions.post(transaction);
+			}
+		})();
 		if (response.status === 200 || response.status === 202) {
 			return Promise.resolve({
 				trxID: transaction.id,


### PR DESCRIPTION
Adds precise fee estimation to all existing writing commands and the ability to boost miner rewards by a multiple for all commands that send transactions. NOTE: the merge destination branch of `cli_v2_smartweave`. We'll want to merge to the `cli_v2` branch once the former has been merged there.