### PR TITLE
Cli v2 use drive key everywhere else

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -328,23 +328,10 @@ export class ArDrive extends ArDriveAnonymous {
 		});
 	}
 
-	async createPrivateDrive(driveName: string, password: string): Promise<ArFSResult> {
+	async createPrivateDrive(driveName: string, driveKey: DriveKey, driveId: DriveID): Promise<ArFSResult> {
 		// Assert that there's enough AR available in the wallet
-		const wallet = this.wallet as JWKWallet;
-		const privKey = wallet.getPrivateKey();
-		const stubRootFolderData = await ArFSPrivateFolderTransactionData.from(
-			driveName,
-			stubEntityID,
-			password,
-			privKey
-		);
-		const stubDriveData = await ArFSPrivateDriveTransactionData.from(
-			driveName,
-			stubEntityID,
-			stubEntityID,
-			password,
-			privKey
-		);
+		const stubRootFolderData = await ArFSPrivateFolderTransactionData.from(driveName, driveKey);
+		const stubDriveData = await ArFSPrivateDriveTransactionData.from(driveName, stubEntityID, driveKey);
 		const driveCreationCosts = await this.estimateAndAssertCostOfDriveCreation(stubDriveData, stubRootFolderData);
 		const driveRewardSettings = {
 			reward: driveCreationCosts.driveMetaDataBaseReward,
@@ -356,7 +343,8 @@ export class ArDrive extends ArDriveAnonymous {
 		};
 		const createDriveResult = await this.arFsDao.createPrivateDrive(
 			driveName,
-			password,
+			driveKey,
+			driveId,
 			driveRewardSettings,
 			rootFolderRewardSettings
 		);

--- a/src/arfs_trx_data_types.ts
+++ b/src/arfs_trx_data_types.ts
@@ -1,14 +1,12 @@
 import {
 	ArFSEncryptedData,
 	CipherType,
-	deriveDriveKey,
 	deriveFileKey,
 	DriveAuthMode,
 	driveEncrypt,
-	fileEncrypt,
-	JWKInterface
+	fileEncrypt
 } from 'ardrive-core-js';
-import { CipherIV, DataContentType, DriveID, DriveKey, FileID, FileKey, FolderID, TransactionID } from './types';
+import { CipherIV, DataContentType, DriveKey, FileID, FileKey, FolderID, TransactionID } from './types';
 
 export interface ArFSObjectTransactionData {
 	asTransactionData(): string | Buffer;
@@ -49,11 +47,8 @@ export class ArFSPrivateDriveTransactionData extends ArFSDriveTransactionData {
 	static async from(
 		name: string,
 		rootFolderId: FolderID,
-		driveId: DriveID,
-		drivePassword: string,
-		privateKey: JWKInterface
+		driveKey: DriveKey
 	): Promise<ArFSPrivateDriveTransactionData> {
-		const driveKey: DriveKey = await deriveDriveKey(drivePassword, driveId, JSON.stringify(privateKey));
 		const { cipher, cipherIV, data } = await driveEncrypt(
 			driveKey,
 			Buffer.from(
@@ -99,13 +94,7 @@ export class ArFSPrivateFolderTransactionData extends ArFSFolderTransactionData 
 		super();
 	}
 
-	static async from(
-		name: string,
-		driveId: DriveID,
-		drivePassword: string,
-		privateKey: JWKInterface
-	): Promise<ArFSPrivateFolderTransactionData> {
-		const driveKey: DriveKey = await deriveDriveKey(drivePassword, driveId, JSON.stringify(privateKey));
+	static async from(name: string, driveKey: DriveKey): Promise<ArFSPrivateFolderTransactionData> {
 		const { cipher, cipherIV, data }: ArFSEncryptedData = await fileEncrypt(
 			driveKey,
 			Buffer.from(

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -384,12 +384,12 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 
 	async createPrivateDrive(
 		driveName: string,
-		password: string,
+		driveKey: DriveKey,
+		driveId: DriveID,
 		driveRewardSettings: RewardSettings,
 		rootFolderRewardSettings: RewardSettings
 	): Promise<ArFSCreatePrivateDriveResult> {
 		// Generate a new drive ID  for the new drive
-		const driveId = uuidv4();
 
 		// Generate a folder ID for the new drive's root folder
 		const rootFolderId = uuidv4();
@@ -397,15 +397,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		// Get the current time so the app can display the "created" data later on
 		const unixTime = Math.round(Date.now() / 1000);
 
-		const wallet = this.wallet as JWKWallet;
-
-		const privateDriveData = await ArFSPrivateDriveTransactionData.from(
-			driveName,
-			rootFolderId,
-			driveId,
-			password,
-			wallet.getPrivateKey()
-		);
+		const privateDriveData = await ArFSPrivateDriveTransactionData.from(driveName, rootFolderId, driveKey);
 
 		// Create a drive metadata transaction
 		const driveMetaData = new ArFSPrivateDriveMetaDataPrototype(unixTime, driveId, privateDriveData);
@@ -416,7 +408,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			unixTime,
 			driveId,
 			rootFolderId,
-			await ArFSPrivateFolderTransactionData.from(driveName, driveId, password, wallet.getPrivateKey())
+			await ArFSPrivateFolderTransactionData.from(driveName, driveKey)
 		);
 		const rootFolderTrx = await this.prepareArFSObjectTransaction(rootFolderMetadata, rootFolderRewardSettings);
 
@@ -431,8 +423,6 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 				await folderUploader.uploadChunk();
 			}
 		}
-
-		const driveKey = privateDriveData.driveKey;
 
 		return {
 			driveTrxId: driveTrx.id,

--- a/src/commands/create_drive.ts
+++ b/src/commands/create_drive.ts
@@ -8,10 +8,10 @@ import {
 	SeedPhraseParameter,
 	WalletFileParameter
 } from '../parameter_declarations';
-import { Wallet } from '../wallet_new';
+import { JWKWallet, Wallet } from '../wallet_new';
 import { arDriveFactory, cliWalletDao } from '..';
 import { FeeMultiple } from '../types';
-import { v4 as uuidv4 } from 'uuid';
+import { PrivateDriveKeyData } from '../ardrive';
 
 /* eslint-disable no-console */
 
@@ -36,10 +36,11 @@ new CLICommand({
 		});
 		const createDriveResult = await (async function () {
 			if (await context.getIsPrivate()) {
-				const driveId = uuidv4();
-				const driveKey = await context.getDriveKey(driveId);
-
-				return ardrive.createPrivateDrive(options.driveName, driveKey, driveId);
+				const newDriveData = await PrivateDriveKeyData.from(
+					options.drivePassword,
+					(wallet as JWKWallet).getPrivateKey()
+				);
+				return ardrive.createPrivateDrive(options.driveName, newDriveData);
 			} else {
 				return ardrive.createPublicDrive(options.driveName);
 			}

--- a/src/commands/create_drive.ts
+++ b/src/commands/create_drive.ts
@@ -11,6 +11,7 @@ import {
 import { Wallet } from '../wallet_new';
 import { arDriveFactory, cliWalletDao } from '..';
 import { FeeMultiple } from '../types';
+import { v4 as uuidv4 } from 'uuid';
 
 /* eslint-disable no-console */
 
@@ -27,6 +28,7 @@ new CLICommand({
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet: Wallet = await context.getWallet();
+
 		const ardrive = arDriveFactory({
 			wallet: wallet,
 			feeMultiple: options.boost as FeeMultiple,
@@ -34,7 +36,10 @@ new CLICommand({
 		});
 		const createDriveResult = await (async function () {
 			if (await context.getIsPrivate()) {
-				return ardrive.createPrivateDrive(options.driveName, options.drivePassword);
+				const driveId = uuidv4();
+				const driveKey = await context.getDriveKey(driveId);
+
+				return ardrive.createPrivateDrive(options.driveName, driveKey, driveId);
 			} else {
 				return ardrive.createPublicDrive(options.driveName);
 			}

--- a/src/commands/drive_info.ts
+++ b/src/commands/drive_info.ts
@@ -25,14 +25,16 @@ new CLICommand({
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet = await context.getWallet().catch(() => null);
-		const result = await (function () {
+		const result = await (async function () {
 			if (wallet) {
 				const arDrive = arDriveFactory({
 					wallet: wallet
 				});
 				const driveId: string = options.driveId;
+				const driveKey = await context.getDriveKey(driveId);
+
 				// const getAllRevisions: boolean = options.getAllRevisions;
-				return arDrive.getPrivateDrive(driveId, options.drivePassword /*, getAllRevisions*/);
+				return arDrive.getPrivateDrive(driveId, driveKey /*, getAllRevisions*/);
 			} else {
 				const arDrive = new ArDriveAnonymous(new ArFSDAOAnonymous(cliArweave));
 				const driveId: string = options.driveId;

--- a/src/commands/folder_info.ts
+++ b/src/commands/folder_info.ts
@@ -25,12 +25,16 @@ new CLICommand({
 	async action(options) {
 		const context = new CommonContext(options, cliWalletDao);
 		const wallet = await context.getWallet().catch(() => null);
-		const result = await (function () {
+		const result = await (async function () {
 			if (wallet) {
 				const arDrive = arDriveFactory({ wallet: wallet });
 				const folderId: string = options.folderId;
+
+				const driveId = await arDrive.getDriveIdForFolderId(folderId);
+				const driveKey = await context.getDriveKey(driveId);
+
 				// const getAllRevisions: boolean = options.getAllRevisions;
-				return arDrive.getPrivateFolder(folderId, options.drivePassword /*, getAllRevisions*/);
+				return arDrive.getPrivateFolder(folderId, driveKey /*, getAllRevisions*/);
 			} else {
 				const arDrive = new ArDriveAnonymous(new ArFSDAOAnonymous(cliArweave));
 				const folderId: string = options.folderId;

--- a/src/commands/list_folder.ts
+++ b/src/commands/list_folder.ts
@@ -47,6 +47,7 @@ new CLICommand({
 			);
 			const driveId = await arDrive.getDriveIdForFolderId(folderId);
 			const driveKey = await context.getDriveKey(driveId);
+
 			children = await arDrive.listPrivateFolder(folderId, driveKey);
 		} else {
 			const arDrive = new ArDriveAnonymous(new ArFSDAOAnonymous(arweave));

--- a/src/commands/upload_file.ts
+++ b/src/commands/upload_file.ts
@@ -1,6 +1,7 @@
 import { GatewayOracle } from 'ardrive-core-js';
-import { arDriveFactory } from '..';
+import { arDriveFactory, cliWalletDao } from '..';
 import { CLICommand } from '../CLICommand';
+import { CommonContext } from '../CLICommand/common_context';
 import {
 	BoostParameter,
 	DestinationFileNameParameter,
@@ -82,6 +83,8 @@ new CLICommand({
 			return [singleParameter];
 		})();
 		if (filesToUpload.length) {
+			const context = new CommonContext(options, cliWalletDao);
+
 			const wallet = readJWKFile(options.walletFile);
 			const priceEstimator: ARDataPriceEstimator = (() => {
 				if (filesToUpload.length > ARDataPriceRegressionEstimator.sampleByteVolumes.length) {
@@ -103,20 +106,21 @@ new CLICommand({
 						console.log(`Bad file: ${JSON.stringify(fileToUpload)}`);
 						process.exit(1);
 					}
+					const { parentFolderId, localFilePath, destinationFileName } = options;
+
 					const result = await (async () => {
-						if (options.drivePassword) {
+						if (await context.getIsPrivate()) {
+							const driveId = await arDrive.getDriveIdForFolderId(parentFolderId);
+							const driveKey = await context.getDriveKey(driveId);
+
 							return arDrive.uploadPrivateFile(
-								fileToUpload.parentFolderId,
-								fileToUpload.localFilePath,
-								options.drivePassword,
-								fileToUpload.destinationFileName
+								parentFolderId,
+								localFilePath,
+								driveKey,
+								destinationFileName
 							);
 						} else {
-							return arDrive.uploadPublicFile(
-								fileToUpload.parentFolderId,
-								fileToUpload.localFilePath,
-								fileToUpload.destinationFileName
-							);
+							return arDrive.uploadPublicFile(parentFolderId, localFilePath, destinationFileName);
 						}
 					})();
 					console.log(JSON.stringify(result, null, 4));


### PR DESCRIPTION
This PR applies the driveKey changes to every command and removes all instances of password and drivePassword in the ArDrive and ArFSDao layers. The commands seem to be working again.