### PR TITLE
chore(husky): Add typecheck to husky hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+
 yarn lint-staged
+yarn typecheck


### PR DESCRIPTION
This PR adds a typecheck command to the husky hook. There seems to be a `tsc-files` command being used in the `lint-staged` command, but that isn't actually preventing a commit properly.

Adding this `yarn typecheck` to the husky hook correctly typechecks locally and will reject non-compliant code. This will prevent a dev from pushing code that will not compile locally rather than failing the CI check.

Notably, I did not add the yarn test command to the hook. It currently takes ~30 seconds to completely test the codebase. Thats a little to long for me, at least on smaller commits. (Edit: ~30 seconds estimate is on a downstream branch that includes testing the seed-phrase code, not currently on the `cli_v2` branch)

I think that we should typecheck, lint, and format locally on before every commit, but testing the codebase should be left up to the dev and then also in the CI pipeline. I'm open to suggestions and discussion on the topic though.