### PR TITLE
fix(create folder): Pass parent folder ID PE-319

### DIFF
--- a/src/commands/create_folder.ts
+++ b/src/commands/create_folder.ts
@@ -31,14 +31,15 @@ new CLICommand({
 			dryRun: options.dryRun
 		});
 
+		const parentFolderId = parameters.getRequiredParameterValue(ParentFolderIdParameter);
 		const driveId = await ardrive.getDriveIdForFolderId(options.parentFolderId);
 
 		const createFolderResult = await (async function () {
 			if (await parameters.getIsPrivate()) {
 				const driveKey = await parameters.getDriveKey(driveId);
-				return ardrive.createPrivateFolder(options.folderName, driveId, driveKey);
+				return ardrive.createPrivateFolder(options.folderName, driveId, driveKey, parentFolderId);
 			} else {
-				return ardrive.createPublicFolder(options.folderName, driveId);
+				return ardrive.createPublicFolder(options.folderName, driveId, parentFolderId);
 			}
 		})();
 		console.log(JSON.stringify(createFolderResult, null, 4));


### PR DESCRIPTION
This PR correctly passes down the required parent folder ID to the create folder methods.