### PR TITLE
fix(drive prototype): Remove duplicate content type tag PE-535

### DIFF
--- a/src/arfs_prototypes.ts
+++ b/src/arfs_prototypes.ts
@@ -67,10 +67,6 @@ export class ArFSPublicDriveMetaDataPrototype extends ArFSDriveMetaDataPrototype
 	) {
 		super();
 	}
-
-	addTagsToTransaction(transaction: Transaction): void {
-		super.addTagsToTransaction(transaction);
-	}
 }
 
 export class ArFSPrivateDriveMetaDataPrototype extends ArFSDriveMetaDataPrototype {


### PR DESCRIPTION
This PR fixes the duplicated content type tag on `createPublicDrive`