### PR TITLE
fix(create drive): Make drive name a required parameter as intended PE-536

### DIFF
--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -69,7 +69,8 @@ Parameter.declare({
 Parameter.declare({
 	name: DriveNameParameter,
 	aliases: ['-n', '--drive-name'],
-	description: `the name for the new drive`
+	description: `the name for the new drive`,
+	required: true
 });
 
 Parameter.declare({


### PR DESCRIPTION
This PR makes the drive name parameter required as the methods in ArDrive and ArFSDao have intended