### PR TITLE
fix(bulk priv upload): Use correct folder base path as name PE-541

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -774,7 +774,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Upload folders, and children of those folders
 		for await (const childFolder of wrappedFolder.folders) {
-			const folderData = await ArFSPrivateFolderTransactionData.from(wrappedFolder.getBaseFileName(), driveKey);
+			const folderData = await ArFSPrivateFolderTransactionData.from(childFolder.getBaseFileName(), driveKey);
 
 			// Recursion alert, will keep creating folders of all nested folders
 			const results = await this.recursivelyCreatePrivateFolderAndUploadChildren({


### PR DESCRIPTION
This PR fixes a naming error on private bulk uploads. Each parent folder was mistakenly naming its child folder.