### PR TITLE
fix(file builder): Assign dataContentType based on file name if missing PE-537

### DIFF
--- a/src/utils/arfs_builders/arfs_file_builders.ts
+++ b/src/utils/arfs_builders/arfs_file_builders.ts
@@ -1,6 +1,7 @@
 import {
 	ContentType,
 	deriveFileKey,
+	extToMime,
 	fileDecrypt,
 	GQLNodeInterface,
 	GQLTagInterface,
@@ -11,6 +12,13 @@ import { ArFSPrivateFile, ArFSPublicFile } from '../../arfs_entities';
 import { ByteCount, CipherIV, DriveKey, FileID, TransactionID, UnixTime } from '../../types';
 import { ArFSFileOrFolderBuilder } from './arfs_builders';
 
+interface FileMetaDataTransactionDataJson {
+	name: string;
+	size: ByteCount;
+	lastModifiedDate: UnixTime;
+	dataTxId: TransactionID;
+	dataContentType: ContentType;
+}
 export abstract class ArFSFileBuilder<T extends ArFSPublicFile | ArFSPrivateFile> extends ArFSFileOrFolderBuilder<T> {
 	size?: ByteCount;
 	lastModifiedDate?: UnixTime;
@@ -51,14 +59,14 @@ export class ArFSPublicFileBuilder extends ArFSFileBuilder<ArFSPublicFile> {
 		) {
 			const txData = await this.arweave.transactions.getData(this.txId, { decode: true });
 			const dataString = await Utf8ArrayToStr(txData);
-			const dataJSON = await JSON.parse(dataString);
+			const dataJSON: FileMetaDataTransactionDataJson = await JSON.parse(dataString);
 
 			// Get the file name
 			this.name = dataJSON.name;
 			this.size = dataJSON.size;
 			this.lastModifiedDate = dataJSON.lastModifiedDate;
 			this.dataTxId = dataJSON.dataTxId;
-			this.dataContentType = dataJSON.dataContentType;
+			this.dataContentType = dataJSON.dataContentType ?? extToMime(this.name);
 
 			if (!this.name || !this.size || !this.lastModifiedDate || !this.dataTxId || !this.dataContentType) {
 				throw new Error('Invalid file state');
@@ -148,14 +156,14 @@ export class ArFSPrivateFileBuilder extends ArFSFileBuilder<ArFSPrivateFile> {
 
 			const decryptedFileBuffer: Buffer = await fileDecrypt(this.cipherIV, fileKey, dataBuffer);
 			const decryptedFileString: string = await Utf8ArrayToStr(decryptedFileBuffer);
-			const decryptedFileJSON = await JSON.parse(decryptedFileString);
+			const decryptedFileJSON: FileMetaDataTransactionDataJson = await JSON.parse(decryptedFileString);
 
 			// Get the file name
 			this.name = decryptedFileJSON.name;
 			this.size = decryptedFileJSON.size;
 			this.lastModifiedDate = decryptedFileJSON.lastModifiedDate;
 			this.dataTxId = decryptedFileJSON.dataTxId;
-			this.dataContentType = decryptedFileJSON.dataContentType;
+			this.dataContentType = decryptedFileJSON.dataContentType ?? extToMime(this.name);
 
 			if (!this.name || !this.size || !this.lastModifiedDate || !this.dataTxId || !this.dataContentType) {
 				throw new Error('Invalid file state');


### PR DESCRIPTION
This PR derives the dataContentType field from the file name if its missing. It also adds an interface for the file dataJSON type so we're not working with `any`