### PR TITLE
PE-518: use MAX_SAFE_INTEGER instead of POSITIVE_INFINITY

### DIFF
--- a/src/CLICommand/parameters_helper.ts
+++ b/src/CLICommand/parameters_helper.ts
@@ -89,12 +89,12 @@ export class ParametersHelper {
 
 	public async getMaxDepth(defaultDepth: number): Promise<number> {
 		if (this.getParameterValue(AllParameter)) {
-			return Number.POSITIVE_INFINITY;
+			return Number.MAX_SAFE_INTEGER;
 		}
 
 		const maxDepthValue = Number(this.getParameterValue(MaxDepthParameter) ?? defaultDepth);
 
-		if ((maxDepthValue !== Number.POSITIVE_INFINITY && !Number.isInteger(maxDepthValue)) || maxDepthValue < 0) {
+		if (!Number.isInteger(maxDepthValue) || maxDepthValue < 0) {
 			throw new Error('maxDepth should be a non-negative integer!');
 		}
 

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -723,7 +723,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		maxDepth: number,
 		includeRoot: boolean
 	): Promise<ArFSPrivateFileOrFolderWithPaths[]> {
-		if ((maxDepth !== Number.POSITIVE_INFINITY && !Number.isInteger(maxDepth)) || maxDepth < 0) {
+		if (!Number.isInteger(maxDepth) || maxDepth < 0) {
 			throw new Error('maxDepth should be a non-negative integer!');
 		}
 

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -149,7 +149,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		maxDepth: number,
 		includeRoot: boolean
 	): Promise<ArFSPublicFileOrFolderWithPaths[]> {
-		if ((maxDepth !== Number.POSITIVE_INFINITY && !Number.isInteger(maxDepth)) || maxDepth < 0) {
+		if (!Number.isInteger(maxDepth) || maxDepth < 0) {
 			throw new Error('maxDepth should be a non-negative integer!');
 		}
 

--- a/src/commands/list_drive.ts
+++ b/src/commands/list_drive.ts
@@ -13,7 +13,7 @@ new CLICommand({
 		const parameters = new ParametersHelper(options, cliWalletDao);
 		const driveId = parameters.getRequiredParameterValue(DriveIdParameter);
 		let children: (ArFSPrivateFileOrFolderWithPaths | ArFSPublicFileOrFolderWithPaths)[];
-		const maxDepth = await parameters.getMaxDepth(Number.POSITIVE_INFINITY);
+		const maxDepth = await parameters.getMaxDepth(Number.MAX_SAFE_INTEGER);
 
 		if (await parameters.getIsPrivate()) {
 			const wallet = await parameters.getRequiredWallet();

--- a/src/folderHierarchy.ts
+++ b/src/folderHierarchy.ts
@@ -76,7 +76,7 @@ export class FolderHierarchy {
 		return tmpNode;
 	}
 
-	public subTreeOf(folderId: FolderID, maxDepth = Number.POSITIVE_INFINITY): FolderHierarchy {
+	public subTreeOf(folderId: FolderID, maxDepth = Number.MAX_SAFE_INTEGER): FolderHierarchy {
 		const newRootNode = this.folderIdToNodeMap[folderId];
 
 		const subTreeNodes = this.nodeAndChildrenOf(newRootNode, maxDepth);


### PR DESCRIPTION
We might want to use bigint in the future. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER

For now let's limit us to MAX_SAFE_INTEGER