### PR TITLE
feat(list drives): Initialize list drives command PE-547

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1,6 +1,6 @@
 import { ArFSDAO, PrivateDriveKeyData } from './arfsdao';
 import { CommunityOracle } from './community/community_oracle';
-import { deriveDriveKey, DrivePrivacy, GQLTagInterface, winstonToAr } from 'ardrive-core-js';
+import { ArFSDriveEntity, deriveDriveKey, DrivePrivacy, GQLTagInterface, winstonToAr } from 'ardrive-core-js';
 import {
 	TransactionID,
 	ArweaveAddress,
@@ -146,6 +146,14 @@ export class ArDriveAnonymous extends ArDriveType {
 
 	async getPublicFile(fileId: FileID): Promise<ArFSPublicFile> {
 		return this.arFsDao.getPublicFile(fileId);
+	}
+
+	async getAllDrivesForAddress(address: ArweaveAddress, driveKey?: DriveKey): Promise<ArFSDriveEntity[]> {
+		return this.arFsDao.getAllDrivesForAddress(address, driveKey);
+	}
+
+	async getLatestDriveIdForAddress(address: ArweaveAddress): Promise<DriveID> {
+		return this.arFsDao.getLatestDriveIdForAddress(address);
 	}
 
 	/**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,6 +12,7 @@ import './generate_seedphrase';
 import './generate_wallet';
 import './list_folder';
 import './list_drive';
+import './list_drives';
 import './folder_info';
 import './create_folder';
 import './file_info';

--- a/src/commands/list_drives.ts
+++ b/src/commands/list_drives.ts
@@ -1,0 +1,30 @@
+import { arDriveAnonymousFactory, cliWalletDao } from '..';
+import { CLICommand, ParametersHelper } from '../CLICommand';
+import { AddressParameter, DrivePrivacyParameters } from '../parameter_declarations';
+import { DriveKey } from '../types';
+
+new CLICommand({
+	name: 'list-drives',
+	parameters: [AddressParameter, ...DrivePrivacyParameters],
+	async action(options) {
+		const parameters = new ParametersHelper(options, cliWalletDao);
+		const ardrive = arDriveAnonymousFactory();
+
+		const address = await parameters.getWalletAddress();
+
+		let driveKey: DriveKey | undefined = undefined;
+
+		try {
+			const latestDriveId = await ardrive.getLatestDriveIdForAddress(address);
+			driveKey = await parameters.getDriveKey(latestDriveId);
+		} catch {
+			// Gracefully gather driveKey, do nothing with error
+		}
+
+		const drives = await ardrive.getAllDrivesForAddress(address, driveKey);
+
+		// Display data
+		console.log(JSON.stringify(drives, null, 4));
+		process.exit(0);
+	}
+});

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -83,8 +83,8 @@ Parameter.declare({
 Parameter.declare({
 	name: AddressParameter,
 	aliases: ['-a', '--address'],
-	description: 'the address',
-	forbiddenConjunctionParameters: [DrivePasswordParameter, DriveKeyParameter]
+	description: 'the address'
+	// forbiddenConjunctionParameters: [DrivePasswordParameter, DriveKeyParameter]
 });
 
 Parameter.declare({

--- a/src/utils/filter_methods.ts
+++ b/src/utils/filter_methods.ts
@@ -1,3 +1,4 @@
+import { ArFSDriveEntity } from 'ardrive-core-js';
 import { ArFSFileOrFolderEntity } from '../arfs_entities';
 
 /**
@@ -15,6 +16,25 @@ export function latestRevisionFilter(
 	allEntities: ArFSFileOrFolderEntity[]
 ): boolean {
 	const allRevisions = allEntities.filter((e) => e.entityId === entity.entityId);
+	const latestRevision = allRevisions[0];
+	return entity.txId === latestRevision.txId;
+}
+
+/**
+ * @name latestRevisionFilterForDrives is a standard JS find/filter function intended to
+ * filter only the last revision of entities within an array
+ *
+ * @param {ArFSDriveEntity} entity the iterated entity
+ * @param {number} _index the iterated index
+ * @param {ArFSDriveEntity[]} allEntities the array of all entities
+ * @returns {boolean}
+ */
+export function latestRevisionFilterForDrives(
+	entity: ArFSDriveEntity,
+	_index: number,
+	allEntities: ArFSDriveEntity[]
+): boolean {
+	const allRevisions = allEntities.filter((e) => e.driveId === entity.driveId);
 	const latestRevision = allRevisions[0];
 	return entity.txId === latestRevision.txId;
 }


### PR DESCRIPTION
This PR addes the `list-drives` command which will gracefully fetch all of the drive entities for a supplied wallet or arweave address. 

This command operates using only the anonymous ArDrive class. Private drives will only have their `name` and `rootFolderId`  fields decrypted if the provided drive key or drive password succeeds in decrypting the dataJSON. Otherwise they will output:

```shell
"name": "ENCRYPTED",
"rootFolderId": "ENCRYPTED"
```