### PR TITLE
chore(tsconfig): Allow dev env typecheck in test files PE-581

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"ts-sinon": "^2.0.1"
 	},
 	"scripts": {
-		"clean": "rimraf [lib .nyc_output node_modules]",
+		"clean": "rimraf [ lib .nyc_output node_modules coverage ]",
 		"format": "prettier --write \"src/**/*.ts\"",
 		"lint": "eslint . --ext .ts",
 		"lintfix": "eslint . --ext .ts --fix",
@@ -70,7 +70,7 @@
 		"version": "yarn run format && git add -A src",
 		"postversion": "git push && git push --tags",
 		"start": "yarn run build && node ./lib/index.js",
-		"dev": "yarn clean && tsc -w"
+		"dev": "yarn clean && tsc --project ./tsconfig.prod.json -w"
 	},
 	"husky": {
 		"hooks": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"test": "nyc mocha",
 		"coverage": "nyc --reporter text mocha",
 		"typecheck": "tsc --noemit",
-		"build": "yarn clean && tsc",
+		"build": "yarn clean && tsc --project ./tsconfig.prod.json",
 		"ci": "yarn build && yarn test",
 		"version": "yarn run format && git add -A src",
 		"postversion": "git push && git push --tags",

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -422,7 +422,8 @@ function assertUploadFileExpectations(
 	const feeKeys = Object.keys(result.fees);
 	expect(feeKeys[0]).to.match(trxIdRegex);
 	expect(feeKeys[0]).to.equal(fileEntity.dataTxId);
-	expect(result.fees[fileEntity.dataTxId]).to.equal(fileFee);
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	expect(result.fees[fileEntity.dataTxId!]).to.equal(fileFee);
 
 	expect(feeKeys[1]).to.match(trxIdRegex);
 	expect(feeKeys[1]).to.equal(fileEntity.metadataTxId);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,19 @@
 {
-  "compilerOptions": {
-    "target": "es6",
-    "module": "CommonJS",
-    "declaration": true,
-    "moduleResolution": "node",
-    "outDir": "./lib",
-    "strict": true,
-    "esModuleInterop": true,
-    /* Additional Checks */
-    "pretty": true,
-    "sourceMap": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-  },
-  "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+	"compilerOptions": {
+		"target": "es6",
+		"module": "CommonJS",
+		"declaration": true,
+		"moduleResolution": "node",
+		"outDir": "./lib",
+		"strict": true,
+		"esModuleInterop": true,
+		/* Additional Checks */
+		"pretty": true,
+		"sourceMap": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src", "tests"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src"],
+	"exclude": ["tests", "**/*.test.ts"]
+}


### PR DESCRIPTION
This PR adds a prod version of the `tsconfig` file that excludes the test files and allows the dev environment compiler to type-check the tests directory