### PR TITLE
PE-558: Enforce unique file name

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -587,7 +587,7 @@ export class ArDrive extends ArDriveAnonymous {
 		parentFolderId,
 		wrappedFolder,
 		driveId,
-		parentFolderDataOrID: folderData
+		parentFolderDataOrID
 	}: RecursivePublicBulkUploadParams): Promise<{
 		entityResults: ArFSEntityData[];
 		feeResults: ArFSFees;
@@ -596,13 +596,13 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (typeof folderData === 'string') {
+		if (typeof parentFolderDataOrID === 'string') {
 			// Use existing parent folder ID for bulk upload
-			folderId = folderData;
+			folderId = parentFolderDataOrID;
 		} else {
 			// Create the parent folder
 			const createFolderResult = await this.arFsDao.createPublicFolder({
-				folderData: folderData,
+				folderData: parentFolderDataOrID,
 				driveId,
 				rewardSettings: {
 					reward: wrappedFolder.getBaseCosts().metaDataBaseReward,
@@ -841,7 +841,7 @@ export class ArDrive extends ArDriveAnonymous {
 		driveId,
 		parentFolderId,
 		driveKey,
-		parentFolderDataOrID: folderData
+		parentFolderDataOrID
 	}: RecursivePrivateBulkUploadParams): Promise<{
 		entityResults: ArFSEntityData[];
 		feeResults: ArFSFees;
@@ -850,14 +850,14 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (typeof folderData === 'string') {
+		if (typeof parentFolderDataOrID === 'string') {
 			// Use existing parent folder ID for bulk upload.
 			// This happens when the parent folder's name conflicts
-			folderId = folderData;
+			folderId = parentFolderDataOrID;
 		} else {
 			// Create parent folder
 			const createFolderResult = await this.arFsDao.createPrivateFolder({
-				folderData: folderData,
+				folderData: parentFolderDataOrID,
 				driveId,
 				rewardSettings: {
 					reward: wrappedFolder.getBaseCosts().metaDataBaseReward,

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -477,6 +477,18 @@ export class ArDrive extends ArDriveAnonymous {
 	): Promise<ArFSResult> {
 		const driveId = await this.getDriveIdAndAssertDrive(parentFolderId);
 
+		// Derive destination name and names already within provided parent folder
+		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
+		const filesAndFolderNames = await this.arFsDao.getPublicFilesAndFolderNamesForParentFolderId(parentFolderId);
+
+		// File cannot overwrite a folder names
+		if (filesAndFolderNames.folderNames.includes(destFileName)) {
+			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+		}
+
+		// File is a new revision if destination name matches an existing file in the parent folder
+		const existingFileId = filesAndFolderNames.files.find((f) => f.fileName === destFileName)?.fileId;
+
 		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			wrappedFile.fileStats.size,
 			this.stubPublicFileMetadata(wrappedFile, destinationFileName),
@@ -491,7 +503,8 @@ export class ArDrive extends ArDriveAnonymous {
 			driveId,
 			fileDataRewardSettings,
 			metadataRewardSettings,
-			destinationFileName
+			destinationFileName,
+			existingFileId
 		);
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(
@@ -676,6 +689,18 @@ export class ArDrive extends ArDriveAnonymous {
 	): Promise<ArFSResult> {
 		const driveId = await this.getDriveIdAndAssertDrive(parentFolderId, driveKey);
 
+		// Derive destination name and names already within provided parent folder
+		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
+		const filesAndFolderNames = await this.arFsDao.getPublicFilesAndFolderNamesForParentFolderId(parentFolderId);
+
+		// File cannot overwrite a folder names
+		if (filesAndFolderNames.folderNames.includes(destFileName)) {
+			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+		}
+
+		// File is a new revision if destination name matches an existing file in the parent folder
+		const existingFileId = filesAndFolderNames.files.find((f) => f.fileName === destFileName)?.fileId;
+
 		const uploadBaseCosts = await this.estimateAndAssertCostOfFileUpload(
 			wrappedFile.fileStats.size,
 			await this.stubPrivateFileMetadata(wrappedFile, destinationFileName),
@@ -700,7 +725,8 @@ export class ArDrive extends ArDriveAnonymous {
 			driveKey,
 			fileDataRewardSettings,
 			metadataRewardSettings,
-			destinationFileName
+			destinationFileName,
+			existingFileId
 		);
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -493,15 +493,15 @@ export class ArDrive extends ArDriveAnonymous {
 		const fileDataRewardSettings = { reward: uploadBaseCosts.fileDataBaseReward, feeMultiple: this.feeMultiple };
 		const metadataRewardSettings = { reward: uploadBaseCosts.metaDataBaseReward, feeMultiple: this.feeMultiple };
 
-		const uploadFileResult = await this.arFsDao.uploadPublicFile(
+		const uploadFileResult = await this.arFsDao.uploadPublicFile({
 			parentFolderId,
 			wrappedFile,
 			driveId,
 			fileDataRewardSettings,
 			metadataRewardSettings,
-			destinationFileName,
+			destFileName: destinationFileName,
 			existingFileId
-		);
+		});
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(
 			uploadBaseCosts.communityWinstonTip
@@ -643,14 +643,14 @@ export class ArDrive extends ArDriveAnonymous {
 				feeMultiple: this.feeMultiple
 			};
 
-			const uploadFileResult = await this.arFsDao.uploadPublicFile(
-				folderId,
+			const uploadFileResult = await this.arFsDao.uploadPublicFile({
+				parentFolderId: folderId,
 				wrappedFile,
 				driveId,
 				fileDataRewardSettings,
 				metadataRewardSettings,
-				wrappedFile.existingId
-			);
+				existingFileId: wrappedFile.existingId
+			});
 
 			// Capture all file results
 			uploadEntityFees = {
@@ -743,16 +743,16 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// TODO: Add interactive confirmation of AR price estimation
 
-		const uploadFileResult = await this.arFsDao.uploadPrivateFile(
+		const uploadFileResult = await this.arFsDao.uploadPrivateFile({
 			parentFolderId,
 			wrappedFile,
 			driveId,
 			driveKey,
 			fileDataRewardSettings,
 			metadataRewardSettings,
-			destinationFileName,
+			destFileName: destinationFileName,
 			existingFileId
-		);
+		});
 
 		const { tipData, reward: communityTipTrxReward } = await this.sendCommunityTip(
 			uploadBaseCosts.communityWinstonTip
@@ -971,15 +971,15 @@ export class ArDrive extends ArDriveAnonymous {
 				feeMultiple: this.feeMultiple
 			};
 
-			const uploadFileResult = await this.arFsDao.uploadPrivateFile(
-				folderId,
+			const uploadFileResult = await this.arFsDao.uploadPrivateFile({
+				parentFolderId: folderId,
 				wrappedFile,
 				driveId,
 				driveKey,
 				fileDataRewardSettings,
 				metadataRewardSettings,
-				wrappedFile.existingId
-			);
+				existingFileId: wrappedFile.existingId
+			});
 
 			// Capture all file results
 			uploadEntityFees = {

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -890,6 +890,9 @@ export class ArDrive extends ArDriveAnonymous {
 			if (folderNameConflict) {
 				// Assigns existing id for later use
 				folder.existingId = folderNameConflict.folderId;
+
+				// Recurse into existing folder on folder name conflict
+				await this.checkAndAssignExistingNames(folder, getExistingNamesFn);
 			}
 		}
 	}

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -240,6 +240,12 @@ export class ArDrive extends ArDriveAnonymous {
 			throw new Error(errorMessage.cannotMoveIntoSamePlace('File', newParentFolderId));
 		}
 
+		// Assert that there are no duplicate names in the destination folder
+		const entityNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(newParentFolderId);
+		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
+			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+		}
+
 		const fileTransactionData = new ArFSPublicFileMetadataTransactionData(
 			originalFileMetaData.name,
 			originalFileMetaData.size,
@@ -285,6 +291,15 @@ export class ArDrive extends ArDriveAnonymous {
 
 		if (originalFileMetaData.parentFolderId === newParentFolderId) {
 			throw new Error(errorMessage.cannotMoveIntoSamePlace('File', newParentFolderId));
+		}
+
+		// Assert that there are no duplicate names in the destination folder
+		const entityNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
+			newParentFolderId,
+			driveKey
+		);
+		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
+			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
 		}
 
 		const fileTransactionData = await ArFSPrivateFileMetadataTransactionData.from(

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -716,7 +716,10 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided parent folder
 		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPublicFilesAndFolderNamesForParentFolderId(parentFolderId);
+		const filesAndFolderNames = await this.arFsDao.getPrivateFilesAndFolderNamesForParentFolderId(
+			parentFolderId,
+			driveKey
+		);
 
 		// File cannot overwrite a folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -241,9 +241,9 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		// Assert that there are no duplicate names in the destination folder
-		const entityNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(newParentFolderId);
+		const entityNamesInParentFolder = await this.arFsDao.getPublicEntityNamesInFolder(newParentFolderId);
 		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		const fileTransactionData = new ArFSPublicFileMetadataTransactionData(
@@ -294,12 +294,9 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		// Assert that there are no duplicate names in the destination folder
-		const entityNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
-			newParentFolderId,
-			driveKey
-		);
+		const entityNamesInParentFolder = await this.arFsDao.getPrivateEntityNamesInFolder(newParentFolderId, driveKey);
 		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		const fileTransactionData = await ArFSPrivateFileMetadataTransactionData.from(
@@ -480,7 +477,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// File cannot overwrite a folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		// File is a new revision if destination name matches an existing file in the parent folder
@@ -539,7 +536,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Folder cannot overwrite a file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		// Use existing folder if destination name matches an existing folder within the parent folder
@@ -720,7 +717,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// File cannot overwrite a folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		// File is a new revision if destination name matches an existing file in the parent folder
@@ -794,7 +791,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Folder cannot overwrite a file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
-			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
+			throw new Error(errorMessage.entityNameExists);
 		}
 
 		// Use existing folder if destination name matches an existing folder within the parent folder

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -243,6 +243,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPublicEntityNamesInFolder(newParentFolderId);
 		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -296,6 +297,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPrivateEntityNamesInFolder(newParentFolderId, driveKey);
 		if (entityNamesInParentFolder.includes(originalFileMetaData.name)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -356,6 +358,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPublicEntityNamesInFolder(newParentFolderId);
 		if (entityNamesInParentFolder.includes(originalFolderMetaData.name)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -417,6 +420,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPrivateEntityNamesInFolder(newParentFolderId, driveKey);
 		if (entityNamesInParentFolder.includes(originalFolderMetaData.name)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -477,6 +481,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -537,6 +542,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Folders cannot overwrite file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -716,6 +722,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -788,6 +795,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Folders cannot overwrite file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -953,6 +961,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPublicEntityNamesInFolder(parentFolderId);
 		if (entityNamesInParentFolder.includes(folderName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 
@@ -993,6 +1002,7 @@ export class ArDrive extends ArDriveAnonymous {
 		// Assert that there are no duplicate names in the destination folder
 		const entityNamesInParentFolder = await this.arFsDao.getPrivateEntityNamesInFolder(parentFolderId, driveKey);
 		if (entityNamesInParentFolder.includes(folderName)) {
+			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
 

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -336,8 +336,8 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		// Assert that there are no duplicate names in the destination folder
-		const folderNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(newParentFolderId);
-		if (folderNamesInParentFolder.includes(originalFolderMetaData.name)) {
+		const entityNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(newParentFolderId);
+		if (entityNamesInParentFolder.includes(originalFolderMetaData.name)) {
 			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
 		}
 
@@ -397,11 +397,11 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		// Assert that there are no duplicate names in the destination folder
-		const folderNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
+		const entityNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
 			newParentFolderId,
 			driveKey
 		);
-		if (folderNamesInParentFolder.includes(originalFolderMetaData.name)) {
+		if (entityNamesInParentFolder.includes(originalFolderMetaData.name)) {
 			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
 		}
 
@@ -855,8 +855,8 @@ export class ArDrive extends ArDriveAnonymous {
 
 	async createPublicFolder({ folderName, driveId, parentFolderId }: CreatePublicFolderParams): Promise<ArFSResult> {
 		// Assert that there are no duplicate names in the destination folder
-		const folderNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(parentFolderId);
-		if (folderNamesInParentFolder.includes(folderName)) {
+		const entityNamesInParentFolder = await this.arFsDao.getPublicChildNamesOfParentFolderId(parentFolderId);
+		if (entityNamesInParentFolder.includes(folderName)) {
 			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
 		}
 
@@ -895,11 +895,11 @@ export class ArDrive extends ArDriveAnonymous {
 		parentFolderId
 	}: CreatePrivateFolderParams): Promise<ArFSResult> {
 		// Assert that there are no duplicate names in the destination folder
-		const folderNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
+		const entityNamesInParentFolder = await this.arFsDao.getPrivateChildNamesOfParentFolderId(
 			parentFolderId,
 			driveKey
 		);
-		if (folderNamesInParentFolder.includes(folderName)) {
+		if (entityNamesInParentFolder.includes(folderName)) {
 			throw new Error(errorMessage.cannotUseDuplicateNameInParentFolder);
 		}
 

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -552,7 +552,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Estimate and assert the cost of the entire bulk upload
 		// This will assign the calculated base costs to each wrapped file and folder
-		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder, undefined, true);
+		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder);
 
 		// TODO: Add interactive confirmation of price estimation before uploading
 
@@ -805,7 +805,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Estimate and assert the cost of the entire bulk upload
 		// This will assign the calculated base costs to each wrapped file and folder
-		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder, driveKey, true);
+		const bulkEstimation = await this.estimateAndAssertCostOfBulkUpload(wrappedFolder, driveKey);
 
 		// TODO: Add interactive confirmation of price estimation before uploading
 
@@ -1198,10 +1198,23 @@ export class ArDrive extends ArDriveAnonymous {
 		return Promise.resolve(driveEntity);
 	}
 
+	/**
+	 * Utility function to estimate and assert the cost of a bulk upload
+	 *
+	 * @remarks This function will recurse into the folder contents of the provided folderToUpload
+	 *
+	 * @throws when the wallet does not contain enough AR for the bulk upload
+	 *
+	 * @param folderToUpload The wrapped folder to estimate the cost of
+	 * @param driveKey Optional parameter to determine whether to estimate the cost of a private or public upload
+	 * @param isParentFolder Boolean to determine whether to Assert the total cost. This parameter
+	 *   is only to be handled as false internally within the recursive function. Always use default
+	 *   of TRUE when calling this method
+	 *  */
 	async estimateAndAssertCostOfBulkUpload(
 		folderToUpload: ArFSFolderToUpload,
 		driveKey?: DriveKey,
-		isParentFolder = false
+		isParentFolder = true
 	): Promise<{ totalPrice: Winston; totalFilePrice: Winston; communityWinstonTip: Winston }> {
 		let totalPrice = 0;
 		let totalFilePrice = 0;
@@ -1252,7 +1265,7 @@ export class ArDrive extends ArDriveAnonymous {
 		}
 
 		for await (const folder of folderToUpload.folders) {
-			const childFolderResults = await this.estimateAndAssertCostOfBulkUpload(folder, driveKey);
+			const childFolderResults = await this.estimateAndAssertCostOfBulkUpload(folder, driveKey, false);
 
 			totalPrice += +childFolderResults.totalPrice;
 			totalFilePrice += +childFolderResults.totalFilePrice;

--- a/src/arfs_file_wrapper.ts
+++ b/src/arfs_file_wrapper.ts
@@ -101,6 +101,7 @@ export class ArFSFolderToUpload {
 
 	baseCosts?: MetaDataBaseCosts;
 	existingId?: FolderID;
+	destinationName?: string;
 
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		const entitiesInFolder = fs.readdirSync(this.filePath);

--- a/src/arfs_file_wrapper.ts
+++ b/src/arfs_file_wrapper.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { extToMime } from 'ardrive-core-js';
 import { basename, join } from 'path';
-import { ByteCount, DataContentType, UnixTime } from './types';
+import { ByteCount, DataContentType, FileID, FolderID, UnixTime } from './types';
 import { BulkFileBaseCosts, MetaDataBaseCosts } from './ardrive';
 
 type BaseFileName = string;
@@ -60,6 +60,7 @@ export class ArFSFileToUpload {
 	}
 
 	baseCosts?: BulkFileBaseCosts;
+	existingId?: FileID;
 
 	public gatherFileInfo(): FileInfo {
 		const dataContentType = this.getContentType();
@@ -99,6 +100,7 @@ export class ArFSFolderToUpload {
 	folders: ArFSFolderToUpload[] = [];
 
 	baseCosts?: MetaDataBaseCosts;
+	existingId?: FolderID;
 
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		const entitiesInFolder = fs.readdirSync(this.filePath);

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -107,9 +107,9 @@ export interface ArFSMoveParams<O extends ArFSFileOrFolderEntity, T extends ArFS
 	transactionData: T;
 }
 
-export interface FilesAndFolderNames {
+export interface FilesAndFolderNamesIds {
 	files: { fileName: string; fileId: FileID }[];
-	folderNames: string[];
+	folders: { folderName: string; folderId: FolderID }[];
 }
 
 export type GetDriveFunction = () => Promise<ArFSPublicDrive | ArFSPrivateDrive>;
@@ -831,7 +831,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return (await this.getPublicEntitiesWithParentFolderId(folderId, true)).map((f) => f.name);
 	}
 
-	async getFilesAndFolderNames(getEntities: Promise<ArFSFileOrFolderEntity[]>): Promise<FilesAndFolderNames> {
+	async getFilesAndFolderNames(getEntities: Promise<ArFSFileOrFolderEntity[]>): Promise<FilesAndFolderNamesIds> {
 		const allEntities = await getEntities;
 
 		const files = allEntities
@@ -839,19 +839,24 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			.map((f) => {
 				return { fileName: f.name, fileId: f.entityId };
 			});
-		const folderNames = allEntities.filter((e) => e.entityType === 'folder').map((f) => f.name);
 
-		return { files, folderNames };
+		const folders = allEntities
+			.filter((e) => e.entityType === 'folder')
+			.map((f) => {
+				return { folderName: f.name, folderId: f.entityId };
+			});
+
+		return { files, folders };
 	}
 
-	async getPublicFilesAndFolderNamesForParentFolderId(folderId: FolderID): Promise<FilesAndFolderNames> {
+	async getPublicFilesAndFolderNamesForParentFolderId(folderId: FolderID): Promise<FilesAndFolderNamesIds> {
 		return this.getFilesAndFolderNames(this.getPublicEntitiesWithParentFolderId(folderId, true));
 	}
 
 	async getPrivateFilesAndFolderNamesForParentFolderId(
 		folderId: FolderID,
 		driveKey: DriveKey
-	): Promise<FilesAndFolderNames> {
+	): Promise<FilesAndFolderNamesIds> {
 		return this.getFilesAndFolderNames(this.getPrivateEntitiesWithParentFolderId(folderId, driveKey, true));
 	}
 

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -851,14 +851,14 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	}
 
 	async getPublicFilesAndFolderNamesForParentFolderId(folderId: FolderID): Promise<FilesAndFolderNamesIds> {
-		return this.getFilesAndFolderNames(this.getPublicEntitiesWithParentFolderId(folderId, true));
+		return this.getFilesAndFolderNames(this.getPublicEntitiesInFolder(folderId, true));
 	}
 
 	async getPrivateFilesAndFolderNamesForParentFolderId(
 		folderId: FolderID,
 		driveKey: DriveKey
 	): Promise<FilesAndFolderNamesIds> {
-		return this.getFilesAndFolderNames(this.getPrivateEntitiesWithParentFolderId(folderId, driveKey, true));
+		return this.getFilesAndFolderNames(this.getPrivateEntitiesInFolder(folderId, driveKey, true));
 	}
 
 	async getPrivateChildrenFolderIds({

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -116,6 +116,20 @@ export interface ArFSMoveParams<O extends ArFSFileOrFolderEntity, T extends ArFS
 export type GetDriveFunction = () => Promise<ArFSPublicDrive | ArFSPrivateDrive>;
 export type CreateFolderFunction = (driveId: DriveID) => Promise<ArFSCreateFolderResult>;
 export type GenerateDriveIdFn = () => DriveID;
+
+export interface UploadPublicFileParams {
+	parentFolderId: FolderID;
+	wrappedFile: ArFSFileToUpload;
+	driveId: DriveID;
+	fileDataRewardSettings: RewardSettings;
+	metadataRewardSettings: RewardSettings;
+	destFileName?: string;
+	existingFileId?: FileID;
+}
+
+export interface UploadPrivateFileParams extends UploadPublicFileParams {
+	driveKey: DriveKey;
+}
 export interface CreateFolderSettings {
 	driveId: DriveID;
 	rewardSettings: RewardSettings;
@@ -504,15 +518,15 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		);
 	}
 
-	async uploadPublicFile(
-		parentFolderId: FolderID,
-		wrappedFile: ArFSFileToUpload,
-		driveId: DriveID,
-		fileDataRewardSettings: RewardSettings,
-		metadataRewardSettings: RewardSettings,
-		destFileName?: string,
-		existingFileId?: FileID
-	): Promise<ArFSUploadFileResult> {
+	async uploadPublicFile({
+		parentFolderId,
+		wrappedFile,
+		driveId,
+		fileDataRewardSettings,
+		metadataRewardSettings,
+		destFileName,
+		existingFileId
+	}: UploadPublicFileParams): Promise<ArFSUploadFileResult> {
 		return this.uploadFile(
 			wrappedFile,
 			fileDataRewardSettings,
@@ -541,16 +555,16 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		);
 	}
 
-	async uploadPrivateFile(
-		parentFolderId: FolderID,
-		wrappedFile: ArFSFileToUpload,
-		driveId: DriveID,
-		driveKey: DriveKey,
-		fileDataRewardSettings: RewardSettings,
-		metadataRewardSettings: RewardSettings,
-		destFileName?: string,
-		existingFileId?: FileID
-	): Promise<ArFSUploadPrivateFileResult> {
+	async uploadPrivateFile({
+		parentFolderId,
+		wrappedFile,
+		driveId,
+		driveKey,
+		fileDataRewardSettings,
+		metadataRewardSettings,
+		destFileName,
+		existingFileId
+	}: UploadPrivateFileParams): Promise<ArFSUploadPrivateFileResult> {
 		return this.uploadFile(
 			wrappedFile,
 			fileDataRewardSettings,

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -107,7 +107,7 @@ export interface ArFSMoveParams<O extends ArFSFileOrFolderEntity, T extends ArFS
 	transactionData: T;
 }
 
-export interface FilesAndFolderNamesIds {
+export interface EntityNamesAndIds {
 	files: { fileName: string; fileId: FileID }[];
 	folders: { folderName: string; folderId: FolderID }[];
 }
@@ -452,7 +452,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		// Establish destination file name
 		const destinationFileName = destFileName ?? wrappedFile.getBaseFileName();
 
-		// Generate file ID
+		// Use existing file ID (create a revision) or generate new file ID
 		const fileId = existingFileId ?? uuidv4();
 
 		// Gather file information
@@ -832,7 +832,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return (await this.getPublicEntitiesInFolder(folderId, true)).map((f) => f.name);
 	}
 
-	async getFilesAndFolderNames(getEntities: Promise<ArFSFileOrFolderEntity[]>): Promise<FilesAndFolderNamesIds> {
+	async getFilesAndFolderNames(getEntities: Promise<ArFSFileOrFolderEntity[]>): Promise<EntityNamesAndIds> {
 		const allEntities = await getEntities;
 
 		const files = allEntities
@@ -850,14 +850,11 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return { files, folders };
 	}
 
-	async getPublicFilesAndFolderNamesForParentFolderId(folderId: FolderID): Promise<FilesAndFolderNamesIds> {
+	async getPublicEntityNamesAndIdsInFolder(folderId: FolderID): Promise<EntityNamesAndIds> {
 		return this.getFilesAndFolderNames(this.getPublicEntitiesInFolder(folderId, true));
 	}
 
-	async getPrivateFilesAndFolderNamesForParentFolderId(
-		folderId: FolderID,
-		driveKey: DriveKey
-	): Promise<FilesAndFolderNamesIds> {
+	async getPrivateEntityNamesAndIdsInFolder(folderId: FolderID, driveKey: DriveKey): Promise<EntityNamesAndIds> {
 		return this.getFilesAndFolderNames(this.getPrivateEntitiesInFolder(folderId, driveKey, true));
 	}
 

--- a/src/utils/filter_methods.ts
+++ b/src/utils/filter_methods.ts
@@ -1,5 +1,6 @@
 import { ArFSDriveEntity } from 'ardrive-core-js';
 import { ArFSFileOrFolderEntity } from '../arfs_entities';
+import { FileID, FolderID } from '../types';
 
 /**
  * @name lastRevisionFilter is a standard JS find/filter function intended to
@@ -37,4 +38,29 @@ export function latestRevisionFilterForDrives(
 	const allRevisions = allEntities.filter((e) => e.driveId === entity.driveId);
 	const latestRevision = allRevisions[0];
 	return entity.txId === latestRevision.txId;
+}
+
+export interface EntityNamesAndIds {
+	files: { fileName: string; fileId: FileID }[];
+	folders: { folderName: string; folderId: FolderID }[];
+}
+
+export function filterEntitiesToNamesAndIds(entities: ArFSFileOrFolderEntity[]): EntityNamesAndIds {
+	const files = entities
+		.filter((e) => e.entityType === 'file')
+		.map((f) => {
+			return { fileName: f.name, fileId: f.entityId };
+		});
+
+	const folders = entities
+		.filter((e) => e.entityType === 'folder')
+		.map((f) => {
+			return { folderName: f.name, folderId: f.entityId };
+		});
+
+	return { files, folders };
+}
+
+export function filterEntitiesToNames(entities: ArFSFileOrFolderEntity[]): string[] {
+	return entities.map((f) => f.name);
 }

--- a/src/utils/filter_methods.ts
+++ b/src/utils/filter_methods.ts
@@ -44,5 +44,5 @@ export function fileFilter(entity: ArFSFileOrFolderEntity): boolean {
 }
 
 export function folderFilter(entity: ArFSFileOrFolderEntity): boolean {
-	return entity.entityType === 'file';
+	return entity.entityType === 'folder';
 }

--- a/src/utils/stubs.ts
+++ b/src/utils/stubs.ts
@@ -12,7 +12,7 @@ export const stubArweaveAddress = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH';
 export const stubTransactionID = '0000000000000000000000000000000000000000000';
 
 export const stubEntityID = '00000000-0000-0000-0000-000000000000';
-export const stubEntityIDAlt = '00000000-0000-0000-0000-000000000001';
+export const stubEntityIDAlt = 'caa8b54a-eb5e-4134-8ae2-a3946a428ec7';
 
 export const stubEntityIDRoot = '00000000-0000-0000-0000-000000000002';
 export const stubEntityIDParent = '00000000-0000-0000-0000-000000000003';

--- a/src/utils/stubs.ts
+++ b/src/utils/stubs.ts
@@ -96,40 +96,42 @@ export const stubPrivateFolder = ({
 		'stubIV'
 	);
 
-export const stubPublicFile = new ArFSPublicFile(
-	'Integration Test',
-	'1.0',
-	ArFS_O_11,
-	'application/json',
-	stubEntityID,
-	'file',
-	'STUB NAME',
-	stubTransactionID,
-	0,
-	stubEntityID,
-	stubEntityID,
-	1234567890,
-	0,
-	stubTransactionID,
-	'application/json'
-);
+export const stubPublicFile = (fileName = 'STUB NAME'): ArFSPublicFile =>
+	new ArFSPublicFile(
+		'Integration Test',
+		'1.0',
+		ArFS_O_11,
+		'application/json',
+		stubEntityID,
+		'file',
+		fileName,
+		stubTransactionID,
+		0,
+		stubEntityID,
+		stubEntityID,
+		1234567890,
+		0,
+		stubTransactionID,
+		'application/json'
+	);
 
-export const stubPrivateFile = new ArFSPrivateFile(
-	'Integration Test',
-	'1.0',
-	ArFS_O_11,
-	'application/json',
-	stubEntityID,
-	'file',
-	'STUB NAME',
-	stubTransactionID,
-	0,
-	stubEntityID,
-	stubEntityID,
-	1234567890,
-	0,
-	stubTransactionID,
-	'application/json',
-	'stubCipher',
-	'stubIV'
-);
+export const stubPrivateFile = (fileName = 'STUB NAME'): ArFSPrivateFile =>
+	new ArFSPrivateFile(
+		'Integration Test',
+		'1.0',
+		ArFS_O_11,
+		'application/json',
+		stubEntityID,
+		'file',
+		fileName,
+		stubTransactionID,
+		0,
+		stubEntityID,
+		stubEntityID,
+		1234567890,
+		0,
+		stubTransactionID,
+		'application/json',
+		'stubCipher',
+		'stubIV'
+	);

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -401,7 +401,7 @@ describe('ArDrive class - integrated', () => {
 					stub(communityOracle, 'getCommunityWinstonTip').resolves('1');
 					stub(communityOracle, 'selectTokenHolder').resolves(stubArweaveAddress);
 
-					stub(arfsDao, 'getPublicFilesAndFolderNamesForParentFolderId').resolves({
+					stub(arfsDao, 'getPublicEntityNamesAndIdsInFolder').resolves({
 						files: [{ fileName: 'CONFLICTING_FILE_NAME', fileId: existingFileId }],
 						folders: [{ folderName: 'CONFLICTING_FOLDER_NAME', folderId: stubEntityID }]
 					});
@@ -414,7 +414,7 @@ describe('ArDrive class - integrated', () => {
 					});
 				});
 
-				it('returns the correct ArFSResult if destination folder has a conflicting FILE name ', async () => {
+				it('returns the correct ArFSResult revision if destination folder has a conflicting FILE name', async () => {
 					const result = await arDrive.uploadPublicFile(stubEntityID, wrappedFile, 'CONFLICTING_FILE_NAME');
 
 					// Pass expected existing file id, so that the file would be considered a revision
@@ -436,7 +436,7 @@ describe('ArDrive class - integrated', () => {
 					stub(communityOracle, 'getCommunityWinstonTip').resolves('1');
 					stub(communityOracle, 'selectTokenHolder').resolves(stubArweaveAddress);
 
-					stub(arfsDao, 'getPrivateFilesAndFolderNamesForParentFolderId').resolves({
+					stub(arfsDao, 'getPrivateEntityNamesAndIdsInFolder').resolves({
 						files: [{ fileName: 'CONFLICTING_FILE_NAME', fileId: existingFileId }],
 						folders: [{ folderName: 'CONFLICTING_FOLDER_NAME', folderId: stubEntityID }]
 					});
@@ -454,7 +454,7 @@ describe('ArDrive class - integrated', () => {
 					});
 				});
 
-				it('returns the correct ArFSResult if destination folder has a conflicting FILE name ', async () => {
+				it('returns the correct ArFSResult revision if destination folder has a conflicting FILE name', async () => {
 					const result = await arDrive.uploadPrivateFile(
 						stubEntityID,
 						wrappedFile,

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -410,7 +410,7 @@ describe('ArDrive class - integrated', () => {
 				it('throws an error if destination folder has a conflicting FOLDER name', async () => {
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.uploadPublicFile(stubEntityID, wrappedFile, 'CONFLICTING_FOLDER_NAME'),
-						errorMessage: 'Parent folder already has an entity with the name!'
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 
@@ -450,7 +450,7 @@ describe('ArDrive class - integrated', () => {
 							await getStubDriveKey(),
 							'CONFLICTING_FOLDER_NAME'
 						),
-						errorMessage: 'Parent folder already has an entity with the name!'
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 
@@ -475,7 +475,7 @@ describe('ArDrive class - integrated', () => {
 
 			describe('movePublicFile', () => {
 				beforeEach(() => {
-					stub(arfsDao, 'getPublicChildNamesOfParentFolderId').resolves(['CONFLICTING_NAME']);
+					stub(arfsDao, 'getPublicEntityNamesInFolder').resolves(['CONFLICTING_NAME']);
 				});
 
 				it('throws an error if the destination folder has a conflicting entity name', async () => {
@@ -484,7 +484,7 @@ describe('ArDrive class - integrated', () => {
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.movePublicFile(stubEntityID, stubEntityIDAlt),
-						errorMessage: 'Parent folder already has an entity with the name!'
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 
@@ -516,7 +516,7 @@ describe('ArDrive class - integrated', () => {
 
 			describe('movePrivateFile', () => {
 				beforeEach(() => {
-					stub(arfsDao, 'getPrivateChildNamesOfParentFolderId').resolves(['CONFLICTING_NAME']);
+					stub(arfsDao, 'getPrivateEntityNamesInFolder').resolves(['CONFLICTING_NAME']);
 				});
 
 				it('throws an error if the destination folder has a conflicting entity name', async () => {
@@ -525,7 +525,7 @@ describe('ArDrive class - integrated', () => {
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.movePrivateFile(stubEntityID, stubEntityIDAlt, await getStubDriveKey()),
-						errorMessage: 'Parent folder already has an entity with the name!'
+						errorMessage: 'Entity name already exists in destination folder!'
 					});
 				});
 


### PR DESCRIPTION
This PR enforces unique file names within the supplied destination folder for `upload-file` and `move-file`.

#### Expected behavior for move file:
- Errors out if destination folder has conflicting FILE or FOLDER name

#### Expected behavior for upload file performed on a single file:
- Errors out if destination folder has conflicting FOLDER name
- Uploads as a REVISION if destination folder has conflicting FILE name

#### Expected behavior for upload file performed on a folder (uploads -- for all entities within the tree):
- Folder names that conflict with a destination FILE name will error
- Folder names that conflict with destination FOLDER name will use the existing folder ID rather than creating a new folder
- File names that conflict with a destination FOLDER name will error
- File names that conflict with destination FILE name will be uploaded as a REVISION