### PR TITLE
fix(upload file): Lift error check for file path param PE-607

### DIFF
--- a/src/commands/upload_file.ts
+++ b/src/commands/upload_file.ts
@@ -56,14 +56,17 @@ new CLICommand({
 				});
 				return fileParameters;
 			}
+
+			if (!options.localFilePath) {
+				throw new Error('Must provide a local file path!');
+			}
+
 			const singleParameter = {
 				parentFolderId: options.parentFolderId,
 				wrappedEntity: wrapFileOrFolder(options.localFilePath),
 				destinationFileName: options.destFileName
 			};
-			if (!options.parentFolderId || !options.localFilePath) {
-				throw new Error(`Bad file: ${JSON.stringify(singleParameter)}`);
-			}
+
 			return [singleParameter];
 		})();
 		if (filesToUpload.length) {


### PR DESCRIPTION
This PR checks the file path parameter prior to wrapping the file so the user does not see this error message:

```
Cannot read property 'match' of undefined
```

And instead sees:

```
Must provide a local file path!
```