### PR TITLE
PE-563: Derive and assert owner of drive and filter all getters by that owner 

### DIFF
--- a/src/CLICommand/parameters_helper.test.ts
+++ b/src/CLICommand/parameters_helper.test.ts
@@ -250,7 +250,7 @@ describe('ParametersHelper class', () => {
 		it('returns the address of the wallet when a valid --wallet-file is provided', () => {
 			declareCommandWithParams(program, [WalletFileParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+				expect(`${await parameters.getWalletAddress()}`).to.equal(
 					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
 				);
 			});
@@ -260,7 +260,7 @@ describe('ParametersHelper class', () => {
 		it('returns the address of the wallet when a valid --w file is provided', () => {
 			declareCommandWithParams(program, [WalletFileParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+				expect(`${await parameters.getWalletAddress()}`).to.equal(
 					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
 				);
 			});
@@ -272,7 +272,9 @@ describe('ParametersHelper class', () => {
 		// it('returns the address of the wallet when a valid --seed-phrase option is provided', () => {
 		// 	declareCommandWithParams(program, [SeedPhraseParameter], async (options) => {
 		// 		const parameters = new ParametersHelper(options);
-		// expect(await (await parameters.getWalletAddress()).valueOf()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+		// 		expect(`${await parameters.getWalletAddress()}`).to.equal(
+		//			'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+		// 		);
 		// 	});
 		// 	CLICommand.parse(program, [
 		// 		...baseArgv,
@@ -285,7 +287,9 @@ describe('ParametersHelper class', () => {
 		// it('returns the address of the wallet when a valid -s option is provided', () => {
 		// 	declareCommandWithParams(program, [SeedPhraseParameter], async (options) => {
 		// 		const parameters = new ParametersHelper(options);
-		// expect(await (await parameters.getWalletAddress()).valueOf()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+		// 		expect(`${await parameters.getWalletAddress()}`).to.equal(
+		//			'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+		// 		);
 		// 	});
 		// 	CLICommand.parse(program, [
 		// 		...baseArgv,
@@ -298,7 +302,7 @@ describe('ParametersHelper class', () => {
 		it('returns the address provided by the --address option value', () => {
 			declareCommandWithParams(program, [AddressParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+				expect(`${await parameters.getWalletAddress()}`).to.equal(
 					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
 				);
 			});
@@ -313,7 +317,7 @@ describe('ParametersHelper class', () => {
 		it('returns the address provided by the -a option value', () => {
 			declareCommandWithParams(program, [AddressParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+				expect(`${await parameters.getWalletAddress()}`).to.equal(
 					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
 				);
 			});

--- a/src/CLICommand/parameters_helper.test.ts
+++ b/src/CLICommand/parameters_helper.test.ts
@@ -250,7 +250,9 @@ describe('ParametersHelper class', () => {
 		it('returns the address of the wallet when a valid --wallet-file is provided', () => {
 			declareCommandWithParams(program, [WalletFileParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+				);
 			});
 			CLICommand.parse(program, [...baseArgv, testCommandName, '--wallet-file', './test_wallet.json']);
 		});
@@ -258,7 +260,9 @@ describe('ParametersHelper class', () => {
 		it('returns the address of the wallet when a valid --w file is provided', () => {
 			declareCommandWithParams(program, [WalletFileParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+				);
 			});
 			CLICommand.parse(program, [...baseArgv, testCommandName, '-w', './test_wallet.json']);
 		});
@@ -268,7 +272,7 @@ describe('ParametersHelper class', () => {
 		// it('returns the address of the wallet when a valid --seed-phrase option is provided', () => {
 		// 	declareCommandWithParams(program, [SeedPhraseParameter], async (options) => {
 		// 		const parameters = new ParametersHelper(options);
-		// 		expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+		// expect(await (await parameters.getWalletAddress()).valueOf()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
 		// 	});
 		// 	CLICommand.parse(program, [
 		// 		...baseArgv,
@@ -281,7 +285,7 @@ describe('ParametersHelper class', () => {
 		// it('returns the address of the wallet when a valid -s option is provided', () => {
 		// 	declareCommandWithParams(program, [SeedPhraseParameter], async (options) => {
 		// 		const parameters = new ParametersHelper(options);
-		// 		expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+		// expect(await (await parameters.getWalletAddress()).valueOf()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
 		// 	});
 		// 	CLICommand.parse(program, [
 		// 		...baseArgv,
@@ -294,7 +298,9 @@ describe('ParametersHelper class', () => {
 		it('returns the address provided by the --address option value', () => {
 			declareCommandWithParams(program, [AddressParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+				);
 			});
 			CLICommand.parse(program, [
 				...baseArgv,
@@ -307,7 +313,9 @@ describe('ParametersHelper class', () => {
 		it('returns the address provided by the -a option value', () => {
 			declareCommandWithParams(program, [AddressParameter], async (options) => {
 				const parameters = new ParametersHelper(options);
-				expect(await parameters.getWalletAddress()).to.equal('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+				expect((await parameters.getWalletAddress()).valueOf()).to.equal(
+					'P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4'
+				);
 			});
 			CLICommand.parse(program, [
 				...baseArgv,

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1168,7 +1168,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async assertOwnerAddress(owner: ArweaveAddress): Promise<void> {
-		if (owner !== (await this.wallet.getAddress())) {
+		if (`${owner}` !== `${await this.wallet.getAddress()}`) {
 			throw new Error('Supplied wallet is not the owner of this drive!');
 		}
 	}

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1051,7 +1051,7 @@ export class ArDrive extends ArDriveAnonymous {
 			newPrivateDriveData,
 			driveRewardSettings,
 			rootFolderRewardSettings,
-			// Owner has been verified by assertPassword
+			// Owner has been verified by assertPassword in the CLI layer
 			await this.wallet.getAddress()
 		);
 

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -47,7 +47,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		return new ArweaveAddress(driveOwnerAddress);
 	}
 
-	private async getDriveID(entityId: EntityID, gqlTypeTag: 'File-Id' | 'Folder-Id') {
+	async getDriveIDForEntityId(entityId: EntityID, gqlTypeTag: 'File-Id' | 'Folder-Id'): Promise<DriveID> {
 		const gqlQuery = buildQuery({ tags: [{ name: gqlTypeTag, value: entityId }] });
 
 		const response = await this.arweave.api.post(graphQLURL, gqlQuery);
@@ -69,11 +69,11 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 	}
 
 	async getDriveIdForFileId(fileId: FileID): Promise<DriveID> {
-		return this.getDriveID(fileId, 'File-Id');
+		return this.getDriveIDForEntityId(fileId, 'File-Id');
 	}
 
 	async getDriveIdForFolderId(folderId: FolderID): Promise<DriveID> {
-		return this.getDriveID(folderId, 'Folder-Id');
+		return this.getDriveIDForEntityId(folderId, 'Folder-Id');
 	}
 
 	// Convenience function for known-public use cases

--- a/src/commands/file_info.ts
+++ b/src/commands/file_info.ts
@@ -21,7 +21,10 @@ new CLICommand({
 
 				const driveKey = await parameters.getDriveKey({ driveId });
 
-				return arDrive.getPrivateFile(fileId, driveKey /*, shouldGetAllRevisions*/);
+				// We have the drive id from deriving a key, we can derive the owner
+				const driveOwner = await arDrive.getOwnerForDriveId(driveId);
+
+				return arDrive.getPrivateFile(fileId, driveKey, driveOwner /*, shouldGetAllRevisions*/);
 			} else {
 				const arDrive = arDriveAnonymousFactory();
 				return arDrive.getPublicFile(fileId /*, shouldGetAllRevisions*/);

--- a/src/commands/folder_info.ts
+++ b/src/commands/folder_info.ts
@@ -22,7 +22,10 @@ new CLICommand({
 				const driveId = await arDrive.getDriveIdForFolderId(folderId);
 				const driveKey = await parameters.getDriveKey({ driveId });
 
-				return arDrive.getPrivateFolder(folderId, driveKey /*, shouldGetAllRevisions*/);
+				// We have the drive id from deriving a key, we can derive the owner
+				const driveOwner = await arDrive.getOwnerForDriveId(driveId);
+
+				return arDrive.getPrivateFolder(folderId, driveKey, driveOwner /*, shouldGetAllRevisions*/);
 			} else {
 				const arDrive = arDriveAnonymousFactory();
 				const folderId: string = options.folderId;

--- a/src/commands/list_drive.ts
+++ b/src/commands/list_drive.ts
@@ -22,7 +22,11 @@ new CLICommand({
 			const driveKey = await parameters.getDriveKey({ driveId });
 			const drive = await arDrive.getPrivateDrive(driveId, driveKey);
 			const rootFolderId = drive.rootFolderId;
-			children = await arDrive.listPrivateFolder(rootFolderId, driveKey, maxDepth, true);
+
+			// We have the drive id from deriving a key, we can derive the owner
+			const driveOwner = await arDrive.getOwnerForDriveId(driveId);
+
+			children = await arDrive.listPrivateFolder(rootFolderId, driveKey, maxDepth, true, driveOwner);
 		} else {
 			const arDrive = new ArDriveAnonymous(new ArFSDAOAnonymous(cliArweave));
 			const drive = await arDrive.getPublicDrive(driveId);

--- a/src/commands/list_folder.ts
+++ b/src/commands/list_folder.ts
@@ -21,7 +21,10 @@ new CLICommand({
 			const driveId = await arDrive.getDriveIdForFolderId(folderId);
 			const driveKey = await parameters.getDriveKey({ driveId });
 
-			children = await arDrive.listPrivateFolder(folderId, driveKey, maxDepth);
+			// We have the drive id from deriving a key, we can derive the owner
+			const driveOwner = await arDrive.getOwnerForDriveId(driveId);
+
+			children = await arDrive.listPrivateFolder(folderId, driveKey, maxDepth, undefined, driveOwner);
 		} else {
 			const arDrive = arDriveAnonymousFactory();
 			children = await arDrive.listPublicFolder(folderId, maxDepth);

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,11 @@
 import { ArweaveAddress } from './arweave_address';
 
+const ownerFragment = `
+	owner {
+		address
+	}
+`;
+
 const nodeFragment = `
 	node {
 		id
@@ -7,6 +13,7 @@ const nodeFragment = `
 			name
 			value
 		}
+		${ownerFragment}
 	}
 `;
 

--- a/src/utils/stubs.ts
+++ b/src/utils/stubs.ts
@@ -7,9 +7,11 @@ import {
 	ArFSPrivateFile
 } from '../arfs_entities';
 import { ArweaveAddress } from '../arweave_address';
-import { ArFS_O_11, FolderID } from '../types';
+import { ArFS_O_11, DriveID, FolderID } from '../types';
 
-export const stubArweaveAddress = new ArweaveAddress('abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH');
+export const stubArweaveAddress = (address = 'abcdefghijklmnopqrxtuvwxyz123456789ABCDEFGH'): ArweaveAddress =>
+	new ArweaveAddress(address);
+
 export const stubTransactionID = '0000000000000000000000000000000000000000000';
 
 export const stubEntityID = '00000000-0000-0000-0000-000000000000';
@@ -55,19 +57,21 @@ interface StubFolderParams {
 	folderId?: FolderID;
 	parentFolderId?: FolderID;
 	folderName?: string;
+	driveId?: DriveID;
 }
 
 export const stubPublicFolder = ({
 	folderId = stubEntityID,
 	parentFolderId = stubEntityID,
-	folderName = 'STUB NAME'
+	folderName = 'STUB NAME',
+	driveId = stubEntityID
 }: StubFolderParams): ArFSPublicFolder =>
 	new ArFSPublicFolder(
 		'Integration Test',
 		'1.0',
 		ArFS_O_11,
 		'application/json',
-		stubEntityID,
+		driveId,
 		'folder',
 		folderName,
 		stubTransactionID,
@@ -79,14 +83,15 @@ export const stubPublicFolder = ({
 export const stubPrivateFolder = ({
 	folderId = stubEntityID,
 	parentFolderId = stubEntityID,
-	folderName = 'STUB NAME'
+	folderName = 'STUB NAME',
+	driveId = stubEntityID
 }: StubFolderParams): ArFSPrivateFolder =>
 	new ArFSPrivateFolder(
 		'Integration Test',
 		'1.0',
 		ArFS_O_11,
 		'application/json',
-		stubEntityID,
+		driveId,
 		'folder',
 		folderName,
 		stubTransactionID,
@@ -97,40 +102,46 @@ export const stubPrivateFolder = ({
 		'stubIV'
 	);
 
-export const stubPublicFile = new ArFSPublicFile(
-	'Integration Test',
-	'1.0',
-	ArFS_O_11,
-	'application/json',
-	stubEntityID,
-	'file',
-	'STUB NAME',
-	stubTransactionID,
-	0,
-	stubEntityID,
-	stubEntityID,
-	1234567890,
-	0,
-	stubTransactionID,
-	'application/json'
-);
+interface StubFileParams {
+	driveId?: DriveID;
+}
 
-export const stubPrivateFile = new ArFSPrivateFile(
-	'Integration Test',
-	'1.0',
-	ArFS_O_11,
-	'application/json',
-	stubEntityID,
-	'file',
-	'STUB NAME',
-	stubTransactionID,
-	0,
-	stubEntityID,
-	stubEntityID,
-	1234567890,
-	0,
-	stubTransactionID,
-	'application/json',
-	'stubCipher',
-	'stubIV'
-);
+export const stubPublicFile = ({ driveId = stubEntityID }: StubFileParams): ArFSPublicFile =>
+	new ArFSPublicFile(
+		'Integration Test',
+		'1.0',
+		ArFS_O_11,
+		'application/json',
+		driveId,
+		'file',
+		'STUB NAME',
+		stubTransactionID,
+		0,
+		stubEntityID,
+		stubEntityID,
+		1234567890,
+		0,
+		stubTransactionID,
+		'application/json'
+	);
+
+export const stubPrivateFile = ({ driveId = stubEntityID }: StubFileParams): ArFSPrivateFile =>
+	new ArFSPrivateFile(
+		'Integration Test',
+		'1.0',
+		ArFS_O_11,
+		'application/json',
+		driveId,
+		'file',
+		'STUB NAME',
+		stubTransactionID,
+		0,
+		stubEntityID,
+		stubEntityID,
+		1234567890,
+		0,
+		stubTransactionID,
+		'application/json',
+		'stubCipher',
+		'stubIV'
+	);

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -89,7 +89,7 @@ describe('ArDrive class - integrated', () => {
 
 				// Can't know the txID ahead of time without mocking arweave deeply
 				expect(result.tipData.txId).to.match(trxIdRegex);
-				expect(result.tipData.recipient.valueOf()).to.equal(stubArweaveAddress().valueOf());
+				expect(`${result.tipData.recipient}`).to.equal(`${stubArweaveAddress()}`);
 				expect(result.tipData.winston).to.equal('12345');
 				expect(result.reward).to.equal('0');
 			});


### PR DESCRIPTION
This PR:  

- Derives the owner of a drive by the earliest transaction with that drive-id
- Asserts the provided wallet is consistent with the drive owner in each method that uses a wallet
- Filters all getters by owner of the drive owner