### PR TITLE
chore(banner): moves the banner function to the index

### DIFF
--- a/src/CLICommand/cli_command.ts
+++ b/src/CLICommand/cli_command.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import { CliApiObject, ParsedArguments } from './cli';
 import { ERROR_EXIT_CODE } from './constants';
 import { Parameter, ParameterName, ParameterOverridenConfig } from './parameter';
@@ -26,10 +26,6 @@ function setCommanderCommand(commandDescriptor: CommandDescriptor, program: CliA
 	let command: CliApiObject = program.command(commandDescriptor.name);
 	const parameters = commandDescriptor.parameters.map((param) => new Parameter(param));
 
-	if (process.env.NODE_ENV !== 'test') {
-		(command as Command).addOption(new Option('--banner').hideHelp());
-	}
-
 	parameters.forEach((parameter) => {
 		const aliasesAsString = parameter.aliases.join(' ');
 		const paramTypeString = (function () {
@@ -54,9 +50,6 @@ function setCommanderCommand(commandDescriptor: CommandDescriptor, program: CliA
 
 	command = command.action(async (options) => {
 		await (async function () {
-			if (options.banner) {
-				displayBanner();
-			}
 			assertConjunctionParameters(commandDescriptor, options);
 			const exitCode = await commandDescriptor.action(options);
 			exitProgram(exitCode || 0);
@@ -65,24 +58,6 @@ function setCommanderCommand(commandDescriptor: CommandDescriptor, program: CliA
 			exitProgram(ERROR_EXIT_CODE);
 		});
 	});
-}
-
-function displayBanner() {
-	console.log('\n');
-	console.log('                          █████╗ ██████╗ ██████╗ ██████╗ ██╗██╗   ██╗███████╗');
-	console.log('                         ██╔══██╗██╔══██╗██╔══██╗██╔══██╗██║██║   ██║██╔════╝');
-	console.log('                         ███████║██████╔╝██║  ██║██████╔╝██║██║   ██║█████╗  ');
-	console.log('                         ██╔══██║██╔══██╗██║  ██║██╔══██╗██║╚██╗ ██╔╝██╔══╝  ');
-	console.log('                         ██║  ██║██║  ██║██████╔╝██║  ██║██║ ╚████╔╝ ███████╗');
-	console.log('                         ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝  ╚══════╝');
-	console.log('                                                                             ');
-	console.log('                                 ██████╗ ███████╗████████╗ █████╗            ');
-	console.log('                                 ██╔══██╗██╔════╝╚══██╔══╝██╔══██╗           ');
-	console.log('                                 ██████╔╝█████╗     ██║   ███████║           ');
-	console.log('                                 ██╔══██╗██╔══╝     ██║   ██╔══██║           ');
-	console.log('                                 ██████╔╝███████╗   ██║   ██║  ██║           ');
-	console.log('                                 ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝           ');
-	console.log('\n');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,3 @@
-import { CLICommand } from '../CLICommand';
 import '../parameter_declarations';
 import './create_drive';
 import './drive_info';
@@ -19,5 +18,3 @@ import './file_info';
 import './move_file';
 import './move_folder';
 import './get_drive_key';
-
-CLICommand.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,20 @@ import { ARDataPriceRegressionEstimator } from './utils/ar_data_price_regression
 import { FeeMultiple } from './types';
 import { CommunityOracle } from './community/community_oracle';
 import { ArFSDAOAnonymous } from './arfsdao_anonymous';
+import { CLICommand } from './CLICommand';
 
 if (require.main === module) {
 	// declare all parameters
 	import('./parameter_declarations').then(() => {
 		// declares the commands
-		import('./commands');
+		import('./commands').then(() => {
+			// early look for the '--banner' flag before parsing the argv
+			const banner = process.argv.includes('--banner');
+			if (banner) {
+				displayBanner();
+			}
+			CLICommand.parse();
+		});
 	});
 }
 
@@ -75,4 +83,22 @@ export function arDriveAnonymousFactory(
 	}
 ): ArDriveAnonymous {
 	return new ArDriveAnonymous(new ArFSDAOAnonymous(settings.arweave ?? cliArweave, CLI_APP_NAME, CLI_APP_VERSION));
+}
+
+function displayBanner() {
+	console.log('\n');
+	console.log('                          █████╗ ██████╗ ██████╗ ██████╗ ██╗██╗   ██╗███████╗');
+	console.log('                         ██╔══██╗██╔══██╗██╔══██╗██╔══██╗██║██║   ██║██╔════╝');
+	console.log('                         ███████║██████╔╝██║  ██║██████╔╝██║██║   ██║█████╗  ');
+	console.log('                         ██╔══██║██╔══██╗██║  ██║██╔══██╗██║╚██╗ ██╔╝██╔══╝  ');
+	console.log('                         ██║  ██║██║  ██║██████╔╝██║  ██║██║ ╚████╔╝ ███████╗');
+	console.log('                         ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═══╝  ╚══════╝');
+	console.log('                                                                             ');
+	console.log('                                 ██████╗ ███████╗████████╗ █████╗            ');
+	console.log('                                 ██╔══██╗██╔════╝╚══██╔══╝██╔══██╗           ');
+	console.log('                                 ██████╔╝█████╗     ██║   ███████║           ');
+	console.log('                                 ██╔══██╗██╔══╝     ██║   ██╔══██║           ');
+	console.log('                                 ██████╔╝███████╗   ██║   ██║  ██║           ');
+	console.log('                                 ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝           ');
+	console.log('\n');
 }


### PR DESCRIPTION
If you run a command with the wrong flags (let's say `get-balance --banner`, but without `-w`), the banner won't be displayed.
Here I moved the function call to the instant before CLICommand parses the `argv`.

_It's even more quick'n dirty but it works :)_