### PR TITLE
fix(owner filter): Pass owner down through list methods PE-645

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -371,7 +371,8 @@ export class ArDrive extends ArDriveAnonymous {
 
 		const childrenFolderIds = await this.arFsDao.getPublicChildrenFolderIds({
 			folderId,
-			driveId: destFolderDriveId
+			driveId: destFolderDriveId,
+			owner
 		});
 
 		if (childrenFolderIds.includes(newParentFolderId)) {
@@ -438,7 +439,8 @@ export class ArDrive extends ArDriveAnonymous {
 		const childrenFolderIds = await this.arFsDao.getPrivateChildrenFolderIds({
 			folderId,
 			driveId: destFolderDriveId,
-			driveKey
+			driveKey,
+			owner
 		});
 
 		if (childrenFolderIds.includes(newParentFolderId)) {

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -183,7 +183,6 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		const allFolders: ArFSPublicFolder[] = [];
 
 		while (hasNextPage) {
-			console.log('owner in getAll', owner);
 			const gqlQuery = buildQuery({
 				tags: [
 					{ name: 'Drive-Id', value: driveId },

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -14,6 +14,12 @@ import { ArweaveAddress } from './arweave_address';
 
 export const graphQLURL = 'https://arweave.net/graphql';
 
+export interface ArFSAllPublicFoldersOfDriveParams {
+	driveId: DriveID;
+	owner: ArweaveAddress;
+	latestRevisionsOnly: boolean;
+}
+
 export interface ArFSListPublicFolderParams {
 	folderId: FolderID;
 	maxDepth: number;
@@ -173,11 +179,11 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		return latestRevisionsOnly ? allFiles.filter(latestRevisionFilter) : allFiles;
 	}
 
-	async getAllFoldersOfPublicDrive(
-		driveId: DriveID,
-		owner: ArweaveAddress,
+	async getAllFoldersOfPublicDrive({
+		driveId,
+		owner,
 		latestRevisionsOnly = false
-	): Promise<ArFSPublicFolder[]> {
+	}: ArFSAllPublicFoldersOfDriveParams): Promise<ArFSPublicFolder[]> {
 		let cursor = '';
 		let hasNextPage = true;
 		const allFolders: ArFSPublicFolder[] = [];
@@ -230,7 +236,11 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 
 		// Fetch all of the folder entities within the drive
 		const driveIdOfFolder = folder.driveId;
-		const allFolderEntitiesOfDrive = await this.getAllFoldersOfPublicDrive(driveIdOfFolder, owner, true);
+		const allFolderEntitiesOfDrive = await this.getAllFoldersOfPublicDrive({
+			driveId: driveIdOfFolder,
+			owner,
+			latestRevisionsOnly: true
+		});
 
 		// Feed entities to FolderHierarchy
 		const hierarchy = FolderHierarchy.newFromEntities(allFolderEntitiesOfDrive);


### PR DESCRIPTION
This PR passes the derived drive owner down into the list methods, which will filter the `list-drive` and `list-folder` commands by the original drive owner.

Fixes #124 