### PR TITLE
PE-633: Uploads will "upsert" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,8 +707,8 @@ Expect the behaviors from the following table for each resolution setting:
 | Source Type | Conflict at Dest | `skip` | `replace` | `upsert` (default) |
 | ----------- | ---------------- | ------ | --------- | ------------------ |
 | File        | None             | Insert | Insert    | Insert             |
-| File        | Matching File    | Skip   | Update    | skip               |
-| File        | Different File   | Skip   | Update    | update             |
+| File        | Matching File    | Skip   | Update    | Skip               |
+| File        | Different File   | Skip   | Update    | Update             |
 | File        | Folder           | Skip   | Fail      | Fail               |
 | Folder      | None             | Insert | Insert    | Insert             |
 | Folder      | File             | Skip   | Fail      | Fail               |

--- a/README.md
+++ b/README.md
@@ -690,7 +690,9 @@ NOTE: To upload to the root of a drive, specify its root folder ID as the parent
 ardrive drive-info -d "c7f87712-b54e-4491-bc96-1c5fa7b1da50" | jq -r '.rootFolderId'
 ```
 
-By default, the single `upload-file` command will skip name conflicts found. To override this behavior and make a new revision of a file, use the `--replace` option:
+By default, the single `upload-file` command will `--upsert` on name conflicts found. This means that when it finds a file in the destination folder with the same name, it will compare the last modified dates of that file and the file to upload. If they are matching, the upload will be skipped, otherwise the upload will be added as a new revision.
+
+To override this behavior, use the `--replace` option to always make new revisions of a file or the `--skip` option to always skip the upload on name conflicts:
 
 ```shell
 ardrive upload-file --replace --local-file-path /path/to/file.txt  --parent-folder-id "9af694f6-4cfc-4eee-88a8-1b02704760c0" -w /path/to/wallet.json
@@ -709,9 +711,9 @@ This method of upload can be used to upload a large number of files and folders 
 -   Folder names that conflict with a FILE name at the destination will cause an error to be thrown
 -   Folder names that conflict with a FOLDER name at the destination will use the existing folder ID (i.e. skip) rather than creating a new folder
 -   File names that conflict with a FOLDER name at the destination will cause an error to be thrown
--   File names that conflict with a FILE name at the destination will be SKIPPED
+-   When the intended file name conflicts with a FILE name at the destination the file will be SKIPPED if the last modified date matches the file to upload. If they have different last modified dates, it will be uploaded as a new REVISION
 
-Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified by the `--replace` command. This will force new revisions on all conflicts within the bulk upload.
+Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified. Use the `--replace` option to will force new revisions on all conflicts within the bulk upload regardless of last modified date. Or use the `--skip` option to simply skip all FILE to FILE name conflicts.
 
 ### Fetching the Metadata of a File Entity
 

--- a/README.md
+++ b/README.md
@@ -690,9 +690,11 @@ NOTE: To upload to the root of a drive, specify its root folder ID as the parent
 ardrive drive-info -d "c7f87712-b54e-4491-bc96-1c5fa7b1da50" | jq -r '.rootFolderId'
 ```
 
-By default, the single `upload-file` command will `--upsert` on name conflicts found. This means that when it finds a file in the destination folder with the same name, it will compare the last modified dates of that file and the file to upload. If they are matching, the upload will be skipped, otherwise the upload will be added as a new revision.
+By default, the single `upload-file` command will use the upsert behavior. It will check the destination folder for a file with a conflicting name. If no conflicts are found, it will insert (upload) the file.
 
-To override this behavior, use the `--replace` option to always make new revisions of a file or the `--skip` option to always skip the upload on name conflicts:
+In the case that there is a FILE to FILE name conflict found, it will only update it if necessary. To determine if an update is necessary, upsert will compare the last modified dates of conflicting file and the file being uploaded. When they are matching, the upload will be skipped. Otherwise the file will be updated as a new revision.
+
+To override the upsert behavior, use the `--replace` option to always make new revisions of a file or the `--skip` option to always skip the upload on name conflicts:
 
 ```shell
 ardrive upload-file --replace --local-file-path /path/to/file.txt  --parent-folder-id "9af694f6-4cfc-4eee-88a8-1b02704760c0" -w /path/to/wallet.json
@@ -713,7 +715,7 @@ This method of upload can be used to upload a large number of files and folders 
 -   File names that conflict with a FOLDER name at the destination will cause an error to be thrown
 -   When the intended file name conflicts with a FILE name at the destination the file will be SKIPPED if the last modified date matches the file to upload. If they have different last modified dates, it will be uploaded as a new REVISION
 
-Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified. Use the `--replace` option to will force new revisions on all conflicts within the bulk upload regardless of last modified date. Or use the `--skip` option to simply skip all FILE to FILE name conflicts.
+Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified. Use the `--replace` option to force new revisions on all conflicts within the bulk upload regardless of last modified date. Or use the `--skip` option to simply skip all FILE to FILE and/or FILE to FOLDER name conflicts.
 
 ### Fetching the Metadata of a File Entity
 

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ This method of upload can be used to upload a large number of files and folders 
 -   File names that conflict with a FOLDER name at the destination will cause an error to be thrown
 -   When the intended file name conflicts with a FILE name at the destination the file will be SKIPPED if the last modified date matches the file to upload. If they have different last modified dates, it will be uploaded as a new REVISION
 
-Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified. Use the `--replace` option to force new revisions on all conflicts within the bulk upload regardless of last modified date. Or use the `--skip` option to simply skip all FILE to FILE and/or FILE to FOLDER name conflicts.
+Similar to the single file upload, the above FILE to FILE name conflict resolution behavior can be modified. Use the `--replace` option to force new revisions on all conflicts within the bulk upload regardless of last modified date. Or use the `--skip` option to simply skip ALL name conflicts.
 
 ### Fetching the Metadata of a File Entity
 

--- a/src/CLICommand/parameters_helper.ts
+++ b/src/CLICommand/parameters_helper.ts
@@ -12,7 +12,7 @@ import {
 	WalletFileParameter,
 	PrivateParameter,
 	ReplaceParameter,
-	UpsertParameter
+	SkipParameter
 } from '../parameter_declarations';
 import { cliWalletDao } from '..';
 import { DriveID, DriveKey } from '../types';
@@ -212,7 +212,7 @@ export class ParametersHelper {
 			return replaceOnConflicts;
 		}
 
-		if (this.getParameterValue(UpsertParameter)) {
+		if (this.getParameterValue(SkipParameter)) {
 			return skipOnConflicts;
 		}
 

--- a/src/CLICommand/parameters_helper.ts
+++ b/src/CLICommand/parameters_helper.ts
@@ -19,7 +19,7 @@ import { DriveID, DriveKey } from '../types';
 import passwordPrompt from 'prompts';
 import { PrivateKeyData } from '../private_key_data';
 import { ArweaveAddress } from '../arweave_address';
-import { FileNameConflictResolution } from '../ardrive';
+import { FileNameConflictResolution, replaceOnConflicts, skipOnConflicts, upsertOnConflicts } from '../ardrive';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ParameterOptions = any;
@@ -209,18 +209,18 @@ export class ParametersHelper {
 
 	public getFileNameConflictResolution(): FileNameConflictResolution {
 		if (this.getParameterValue(ReplaceParameter)) {
-			return 'replace';
+			return replaceOnConflicts;
 		}
 
 		if (this.getParameterValue(UpsertParameter)) {
-			return 'skip';
+			return skipOnConflicts;
 		}
 
 		// if (this.getParameterValue(AskParameter)) {
-		// 	return 'ask'
+		// 	return askOnConflicts;
 		// };
 
-		return 'upsert';
+		return upsertOnConflicts;
 	}
 
 	/**

--- a/src/CLICommand/parameters_helper.ts
+++ b/src/CLICommand/parameters_helper.ts
@@ -11,7 +11,8 @@ import {
 	SeedPhraseParameter,
 	WalletFileParameter,
 	PrivateParameter,
-	ReplaceParameter
+	ReplaceParameter,
+	UpsertParameter
 } from '../parameter_declarations';
 import { cliWalletDao } from '..';
 import { DriveID, DriveKey } from '../types';
@@ -211,15 +212,15 @@ export class ParametersHelper {
 			return 'replace';
 		}
 
-		// if (this.getParameterValue(UpsertParameter)) {
-		// 	return 'upsert'
-		// };
+		if (this.getParameterValue(UpsertParameter)) {
+			return 'skip';
+		}
 
 		// if (this.getParameterValue(AskParameter)) {
 		// 	return 'ask'
 		// };
 
-		return 'skip';
+		return 'upsert';
 	}
 
 	/**

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -678,7 +678,14 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (wrappedFolder.existingId) {
+		if (wrappedFolder.fileNameConflict) {
+			if (conflictResolution === skipOnConflicts) {
+				// Return empty result on skip
+				return { entityResults: [], feeResults: {} };
+			}
+			// Otherwise throw an error, folder names cannot conflict with file names
+			throw new Error(errorMessage.entityNameExists);
+		} else if (wrappedFolder.existingId) {
 			// Use existing parent folder ID for bulk upload
 			folderId = wrappedFolder.existingId;
 		} else {
@@ -1003,7 +1010,7 @@ export class ArDrive extends ArDriveAnonymous {
 		if (wrappedFolder.fileNameConflict) {
 			if (conflictResolution === skipOnConflicts) {
 				// Return empty result on skip
-				return { entityResults: uploadEntityResults, feeResults: uploadEntityFees };
+				return { entityResults: [], feeResults: {} };
 			}
 			// Otherwise throw an error, folder names cannot conflict with file names
 			throw new Error(errorMessage.entityNameExists);

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -518,7 +518,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPublicEntityNamesAndIdsInFolder(parentFolderId);
+		const filesAndFolderNames = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
@@ -602,7 +602,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		const destFolderName = destParentFolderName ?? wrappedFolder.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPublicEntityNamesAndIdsInFolder(parentFolderId);
+		const filesAndFolderNames = await this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId);
 
 		// Folders cannot overwrite file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
@@ -802,7 +802,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		const destFileName = destinationFileName ?? wrappedFile.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPrivateEntityNamesAndIdsInFolder(parentFolderId, driveKey);
+		const filesAndFolderNames = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
@@ -902,7 +902,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Derive destination name and names already within provided destination folder
 		const destFolderName = destParentFolderName ?? wrappedFolder.getBaseFileName();
-		const filesAndFolderNames = await this.arFsDao.getPrivateEntityNamesAndIdsInFolder(parentFolderId, driveKey);
+		const filesAndFolderNames = await this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey);
 
 		// Folders cannot overwrite file names
 		if (filesAndFolderNames.files.find((f) => f.fileName === destFolderName)) {
@@ -1021,7 +1021,7 @@ export class ArDrive extends ArDriveAnonymous {
 
 	protected async checkAndAssignExistingPublicNames(wrappedFolder: ArFSFolderToUpload): Promise<void> {
 		await this.checkAndAssignExistingNames(wrappedFolder, (parentFolderId) =>
-			this.arFsDao.getPublicEntityNamesAndIdsInFolder(parentFolderId)
+			this.arFsDao.getPublicNameConflictInfoInFolder(parentFolderId)
 		);
 	}
 
@@ -1030,7 +1030,7 @@ export class ArDrive extends ArDriveAnonymous {
 		driveKey: DriveKey
 	): Promise<void> {
 		await this.checkAndAssignExistingNames(wrappedFolder, (parentFolderId) =>
-			this.arFsDao.getPrivateEntityNamesAndIdsInFolder(parentFolderId, driveKey)
+			this.arFsDao.getPrivateNameConflictInfoInFolder(parentFolderId, driveKey)
 		);
 	}
 

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -522,6 +522,11 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
+			if (conflictResolution === 'skip') {
+				// Return empty result if resolution set to skip on FILE to FOLDER name conflicts
+				return emptyArFSResult;
+			}
+
 			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}
@@ -806,6 +811,11 @@ export class ArDrive extends ArDriveAnonymous {
 
 		// Files cannot overwrite folder names
 		if (filesAndFolderNames.folders.find((f) => f.folderName === destFileName)) {
+			if (conflictResolution === 'skip') {
+				// Return empty result if resolution set to skip on FILE to FOLDER name conflicts
+				return emptyArFSResult;
+			}
+
 			// TODO: Add optional interactive prompt to resolve name conflicts in ticket PE-599
 			throw new Error(errorMessage.entityNameExists);
 		}

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -678,7 +678,7 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (wrappedFolder.fileNameConflict) {
+		if (wrappedFolder.existingFileAtDestConflict) {
 			if (conflictResolution === skipOnConflicts) {
 				// Return empty result on skip
 				return { entityResults: [], feeResults: {} };
@@ -1007,7 +1007,7 @@ export class ArDrive extends ArDriveAnonymous {
 		let uploadEntityResults: ArFSEntityData[] = [];
 		let folderId: FolderID;
 
-		if (wrappedFolder.fileNameConflict) {
+		if (wrappedFolder.existingFileAtDestConflict) {
 			if (conflictResolution === skipOnConflicts) {
 				// Return empty result on skip
 				return { entityResults: [], feeResults: {} };
@@ -1065,7 +1065,7 @@ export class ArDrive extends ArDriveAnonymous {
 				continue;
 			}
 
-			if (wrappedFile.folderNameConflict) {
+			if (wrappedFile.existingFolderAtDestConflict) {
 				if (conflictResolution === skipOnConflicts) {
 					// Continue loop, skip uploading this file
 					continue;

--- a/src/arfs_file_wrapper.ts
+++ b/src/arfs_file_wrapper.ts
@@ -61,13 +61,18 @@ export class ArFSFileToUpload {
 
 	baseCosts?: BulkFileBaseCosts;
 	existingId?: FileID;
+	hasSameLastModifiedDate = false;
 
 	public gatherFileInfo(): FileInfo {
 		const dataContentType = this.getContentType();
-		const lastModifiedDateMS = Math.floor(this.fileStats.mtimeMs);
+		const lastModifiedDateMS = this.lastModifiedDate;
 		const fileSize = this.fileStats.size;
 
 		return { dataContentType, lastModifiedDateMS, fileSize };
+	}
+
+	public get lastModifiedDate(): UnixTime {
+		return Math.floor(this.fileStats.mtimeMs);
 	}
 
 	public getBaseCosts(): BulkFileBaseCosts {

--- a/src/arfs_file_wrapper.ts
+++ b/src/arfs_file_wrapper.ts
@@ -3,6 +3,7 @@ import { extToMime } from 'ardrive-core-js';
 import { basename, join } from 'path';
 import { ByteCount, DataContentType, FileID, FolderID, UnixTime } from './types';
 import { BulkFileBaseCosts, MetaDataBaseCosts } from './ardrive';
+import { EntityNamesAndIds } from './utils/mapper_functions';
 
 type BaseFileName = string;
 type FilePath = string;
@@ -61,6 +62,7 @@ export class ArFSFileToUpload {
 
 	baseCosts?: BulkFileBaseCosts;
 	existingId?: FileID;
+	folderNameConflict = false;
 	hasSameLastModifiedDate = false;
 
 	public gatherFileInfo(): FileInfo {
@@ -107,6 +109,7 @@ export class ArFSFolderToUpload {
 	baseCosts?: MetaDataBaseCosts;
 	existingId?: FolderID;
 	destinationName?: string;
+	fileNameConflict = false;
 
 	constructor(public readonly filePath: FilePath, public readonly fileStats: fs.Stats) {
 		const entitiesInFolder = fs.readdirSync(this.filePath);
@@ -123,6 +126,70 @@ export class ArFSFolderToUpload {
 				// Child is a file, build a new file
 				const childFile = new ArFSFileToUpload(absoluteEntityPath, entityStats);
 				this.files.push(childFile);
+			}
+		}
+	}
+
+	public async checkAndAssignExistingNames(
+		getExistingNamesFn: (parentFolderId: FolderID) => Promise<EntityNamesAndIds>
+	): Promise<void> {
+		if (!this.existingId) {
+			// Folder has no existing ID to check
+			return;
+		}
+
+		const existingEntityNamesAndIds = await getExistingNamesFn(this.existingId);
+
+		for await (const file of this.files) {
+			const baseFileName = file.getBaseFileName();
+
+			const folderNameConflict = existingEntityNamesAndIds.folders.find(
+				({ folderName }) => folderName === baseFileName
+			);
+
+			if (folderNameConflict) {
+				// Folder name cannot conflict with a file name
+				file.folderNameConflict = true;
+				continue;
+			}
+
+			const fileNameConflict = existingEntityNamesAndIds.files.find(({ fileName }) => fileName === baseFileName);
+
+			// Conflicting file name creates a REVISION by default
+			if (fileNameConflict) {
+				file.existingId = fileNameConflict.fileId;
+
+				if (fileNameConflict.lastModifiedDate === file.lastModifiedDate) {
+					// Check last modified date and set to true to resolve upsert conditional
+					file.hasSameLastModifiedDate = true;
+				}
+			}
+		}
+
+		for await (const folder of this.folders) {
+			const baseFolderName = folder.getBaseFileName();
+
+			const fileNameConflict = existingEntityNamesAndIds.files.find(
+				({ fileName }) => fileName === baseFolderName
+			);
+
+			if (fileNameConflict) {
+				// Folder name cannot conflict with a file name
+				this.fileNameConflict = true;
+				continue;
+			}
+
+			const folderNameConflict = existingEntityNamesAndIds.folders.find(
+				({ folderName }) => folderName === baseFolderName
+			);
+
+			// Conflicting folder name uses EXISTING folder by default
+			if (folderNameConflict) {
+				// Assigns existing id for later use
+				folder.existingId = folderNameConflict.folderId;
+
+				// Recurse into existing folder on folder name conflict
+				await folder.checkAndAssignExistingNames(getExistingNamesFn);
 			}
 		}
 	}

--- a/src/arfs_file_wrapper.ts
+++ b/src/arfs_file_wrapper.ts
@@ -125,7 +125,9 @@ export class ArFSFolderToUpload {
 			} else {
 				// Child is a file, build a new file
 				const childFile = new ArFSFileToUpload(absoluteEntityPath, entityStats);
-				this.files.push(childFile);
+				if (childFile.getBaseFileName() !== '.DS_Store') {
+					this.files.push(childFile);
+				}
 			}
 		}
 	}

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -86,7 +86,12 @@ import { ArFSDAOAnonymous } from './arfsdao_anonymous';
 import { ArFSFileOrFolderBuilder } from './utils/arfs_builders/arfs_builders';
 import { PrivateKeyData } from './private_key_data';
 import { ArweaveAddress } from './arweave_address';
-import { EntityNamesAndIds, entityToNameMap, fileToNameAndIdMap, folderToNameAndIdMap } from './utils/mapper_functions';
+import {
+	EntityNamesAndIds,
+	entityToNameMap,
+	fileConflictInfoMap,
+	folderToNameAndIdMap
+} from './utils/mapper_functions';
 import { ListPrivateFolderParams } from './ardrive';
 
 export const graphQLURL = 'https://arweave.net/graphql';
@@ -858,7 +863,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	async getPublicEntityNamesAndIdsInFolder(folderId: FolderID): Promise<EntityNamesAndIds> {
 		const childrenOfFolder = await this.getPublicEntitiesInFolder(folderId, true);
 		return {
-			files: childrenOfFolder.filter(fileFilter).map(fileToNameAndIdMap),
+			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),
 			folders: childrenOfFolder.filter(folderFilter).map(folderToNameAndIdMap)
 		};
 	}
@@ -866,7 +871,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	async getPrivateEntityNamesAndIdsInFolder(folderId: FolderID, driveKey: DriveKey): Promise<EntityNamesAndIds> {
 		const childrenOfFolder = await this.getPrivateEntitiesInFolder(folderId, driveKey, true);
 		return {
-			files: childrenOfFolder.filter(fileFilter).map(fileToNameAndIdMap),
+			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),
 			folders: childrenOfFolder.filter(folderFilter).map(folderToNameAndIdMap)
 		};
 	}

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -860,7 +860,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		return childrenOfFolder.map(entityToNameMap);
 	}
 
-	async getPublicEntityNamesAndIdsInFolder(folderId: FolderID): Promise<EntityNamesAndIds> {
+	async getPublicNameConflictInfoInFolder(folderId: FolderID): Promise<EntityNamesAndIds> {
 		const childrenOfFolder = await this.getPublicEntitiesInFolder(folderId, true);
 		return {
 			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),
@@ -868,7 +868,7 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 		};
 	}
 
-	async getPrivateEntityNamesAndIdsInFolder(folderId: FolderID, driveKey: DriveKey): Promise<EntityNamesAndIds> {
+	async getPrivateNameConflictInfoInFolder(folderId: FolderID, driveKey: DriveKey): Promise<EntityNamesAndIds> {
 		const childrenOfFolder = await this.getPrivateEntitiesInFolder(folderId, driveKey, true);
 		return {
 			files: childrenOfFolder.filter(fileFilter).map(fileConflictInfoMap),

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -241,7 +241,7 @@ Parameter.declare({
 	name: UpsertParameter,
 	aliases: ['--upsert'],
 	description:
-		'(OPTIONAL) If there is a name conflict within the destination folder and if that file was last modified at the same time as the file to upload, skip the upload',
+		'(OPTIONAL) When there is a name conflict within the destination folder, if that file was last modified at the same time as the file to upload, skip the upload, otherwise upload that file as a new revision',
 	type: 'boolean',
 	forbiddenConjunctionParameters: [SkipParameter, ReplaceParameter]
 });

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -40,7 +40,7 @@ export const DriveCreationPrivacyParameters = [
 export const DrivePrivacyParameters = [DriveKeyParameter, ...DriveCreationPrivacyParameters];
 export const TreeDepthParams = [AllParameter, MaxDepthParameter];
 
-export const ConflictResolutionParams = [SkipParameter, ReplaceParameter /* , UpsertParameter, AskParameter */];
+export const ConflictResolutionParams = [SkipParameter, ReplaceParameter, UpsertParameter /* , AskParameter */];
 
 /**
  * Note: importing this file will declare all the above parameters

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -26,7 +26,7 @@ export const BoostParameter = 'boost';
 export const DryRunParameter = 'dryRun';
 export const SkipParameter = 'skip';
 export const ReplaceParameter = 'replace';
-// export const UpsertParameter = 'upsert';
+export const UpsertParameter = 'upsert';
 // export const AskParameter = 'ask';
 export const NoVerifyParameter = 'verify'; // commander maps --no-x style params to options.x and always includes in options
 
@@ -226,7 +226,7 @@ Parameter.declare({
 	aliases: ['--skip'],
 	description: '(OPTIONAL) Skip upload if there is a name conflict within destination folder',
 	type: 'boolean',
-	forbiddenConjunctionParameters: [ReplaceParameter]
+	forbiddenConjunctionParameters: [ReplaceParameter, UpsertParameter]
 });
 
 Parameter.declare({
@@ -234,7 +234,16 @@ Parameter.declare({
 	aliases: ['--replace'],
 	description: '(OPTIONAL) Create new file revisions if there is a name conflict within destination folder',
 	type: 'boolean',
-	forbiddenConjunctionParameters: [SkipParameter]
+	forbiddenConjunctionParameters: [SkipParameter, UpsertParameter]
+});
+
+Parameter.declare({
+	name: UpsertParameter,
+	aliases: ['--upsert'],
+	description:
+		'(OPTIONAL) If there is a name conflict within the destination folder and if that file was last modified at the same time as the file to upload, skip the upload',
+	type: 'boolean',
+	forbiddenConjunctionParameters: [SkipParameter, ReplaceParameter]
 });
 
 Parameter.declare({

--- a/src/utils/mapper_functions.ts
+++ b/src/utils/mapper_functions.ts
@@ -1,8 +1,8 @@
 import { ArFSFileOrFolderEntity } from '../arfs_entities';
-import { FileID, FolderID } from '../types';
+import { FileID, FolderID, UnixTime } from '../types';
 
 export interface EntityNamesAndIds {
-	files: FileNameAndId[];
+	files: FileConflictInfo[];
 	folders: FolderNameAndId[];
 }
 
@@ -11,9 +11,10 @@ interface FolderNameAndId {
 	folderId: FolderID;
 }
 
-interface FileNameAndId {
+interface FileConflictInfo {
 	fileName: string;
 	fileId: FileID;
+	lastModifiedDate: UnixTime;
 }
 
 export function entityToNameMap(entity: ArFSFileOrFolderEntity): string {
@@ -24,6 +25,6 @@ export function folderToNameAndIdMap(entity: ArFSFileOrFolderEntity): FolderName
 	return { folderId: entity.entityId, folderName: entity.name };
 }
 
-export function fileToNameAndIdMap(entity: ArFSFileOrFolderEntity): FileNameAndId {
-	return { fileId: entity.entityId, fileName: entity.name };
+export function fileConflictInfoMap(entity: ArFSFileOrFolderEntity): FileConflictInfo {
+	return { fileId: entity.entityId, fileName: entity.name, lastModifiedDate: entity.lastModifiedDate };
 }

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -461,7 +461,7 @@ describe('ArDrive class - integrated', () => {
 					stub(communityOracle, 'getCommunityWinstonTip').resolves('1');
 					stub(communityOracle, 'selectTokenHolder').resolves(stubArweaveAddress());
 
-					stub(arfsDao, 'getPublicEntityNamesAndIdsInFolder').resolves({
+					stub(arfsDao, 'getPublicNameConflictInfoInFolder').resolves({
 						files: [
 							{
 								fileName: 'CONFLICTING_FILE_NAME',
@@ -574,7 +574,7 @@ describe('ArDrive class - integrated', () => {
 					stub(communityOracle, 'getCommunityWinstonTip').resolves('1');
 					stub(communityOracle, 'selectTokenHolder').resolves(stubArweaveAddress());
 
-					stub(arfsDao, 'getPrivateEntityNamesAndIdsInFolder').resolves({
+					stub(arfsDao, 'getPrivateNameConflictInfoInFolder').resolves({
 						files: [
 							{
 								fileName: 'CONFLICTING_FILE_NAME',


### PR DESCRIPTION
This PR adds the `--upsert` parameter which will become the new default on single and bulk file uploads. 

On a FILE to FILE name conflict within the destination folder, the upsert option will compare `lastModifiedDate` on the files. If they match, the upload will be skipped. Otherwise a new REVISION will be created.