### PR TITLE
PE-635 Bug Fixes

### DIFF
--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -378,7 +378,7 @@ export class ArDrive extends ArDriveAnonymous {
 			owner
 		});
 
-		if (childrenFolderIds.includes(newParentFolderId)) {
+		if (childrenFolderIds.some((fid) => fid.equals(newParentFolderId))) {
 			throw new Error(errorMessage.cannotMoveParentIntoChildFolder);
 		}
 
@@ -446,7 +446,7 @@ export class ArDrive extends ArDriveAnonymous {
 			owner
 		});
 
-		if (childrenFolderIds.includes(newParentFolderId)) {
+		if (childrenFolderIds.some((fid) => fid.equals(newParentFolderId))) {
 			throw new Error(errorMessage.cannotMoveParentIntoChildFolder);
 		}
 

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -262,7 +262,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		const [, ...subFolderIDs]: FolderID[] = hierarchy.folderIdSubtreeFromFolderId(folderId, maxDepth);
 
 		const childrenFolderEntities = allFolderEntitiesOfDrive.filter((folder) =>
-			subFolderIDs.includes(folder.entityId)
+			subFolderIDs.some((fid) => fid.equals(folder.entityId))
 		);
 
 		if (includeRoot) {

--- a/src/commands/move_file.ts
+++ b/src/commands/move_file.ts
@@ -10,6 +10,7 @@ import { Wallet } from '../wallet';
 import { arDriveFactory } from '..';
 import { SUCCESS_EXIT_CODE } from '../CLICommand/error_codes';
 import { CLIAction } from '../CLICommand/action';
+import { EID } from '../types';
 
 new CLICommand({
 	name: 'move-file',
@@ -17,7 +18,9 @@ new CLICommand({
 	action: new CLIAction(async function action(options) {
 		const parameters = new ParametersHelper(options);
 
-		const { fileId, parentFolderId, dryRun } = options;
+		const { dryRun } = options;
+		const fileId = EID(options.fileId);
+		const parentFolderId = EID(options.parentFolderId);
 
 		const wallet: Wallet = await parameters.getRequiredWallet();
 		const ardrive = arDriveFactory({

--- a/src/commands/move_folder.ts
+++ b/src/commands/move_folder.ts
@@ -10,6 +10,7 @@ import { Wallet } from '../wallet';
 import { arDriveFactory } from '..';
 import { SUCCESS_EXIT_CODE } from '../CLICommand/error_codes';
 import { CLIAction } from '../CLICommand/action';
+import { EID } from '../types';
 
 new CLICommand({
 	name: 'move-folder',
@@ -23,7 +24,9 @@ new CLICommand({
 	action: new CLIAction(async function action(options) {
 		const parameters = new ParametersHelper(options);
 
-		const { folderId, parentFolderId: newParentFolderId, dryRun } = options;
+		const { dryRun } = options;
+		const folderId = EID(options.folderId);
+		const newParentFolderId = EID(options.parentFolderId);
 
 		const wallet: Wallet = await parameters.getRequiredWallet();
 		const ardrive = arDriveFactory({

--- a/src/commands/tx_status.ts
+++ b/src/commands/tx_status.ts
@@ -13,7 +13,7 @@ new CLICommand({
 		const { confirmations } = options;
 		const txId = new TransactionID(options.txId);
 		const transactionsInMempool = (await fetchMempool()).map((id) => new TransactionID(id));
-		const pending = transactionsInMempool.includes(txId);
+		const pending = transactionsInMempool.some((tx) => tx.equals(txId));
 		const confirmationAmount = confirmations ?? 15;
 
 		if (pending) {

--- a/src/commands/tx_status.ts
+++ b/src/commands/tx_status.ts
@@ -3,14 +3,16 @@ import { CLICommand } from '../CLICommand';
 import { CLIAction } from '../CLICommand/action';
 import { ERROR_EXIT_CODE, SUCCESS_EXIT_CODE } from '../CLICommand/error_codes';
 import { ConfirmationsParameter, TransactionIdParameter } from '../parameter_declarations';
+import { TransactionID } from '../types';
 import { fetchMempool } from '../utils';
 
 new CLICommand({
 	name: 'tx-status',
 	parameters: [TransactionIdParameter, ConfirmationsParameter],
 	action: new CLIAction(async function action(options) {
-		const { txId, confirmations } = options;
-		const transactionsInMempool = await fetchMempool();
+		const { confirmations } = options;
+		const txId = new TransactionID(options.txId);
+		const transactionsInMempool = (await fetchMempool()).map((id) => new TransactionID(id));
 		const pending = transactionsInMempool.includes(txId);
 		const confirmationAmount = confirmations ?? 15;
 
@@ -19,7 +21,7 @@ new CLICommand({
 			return SUCCESS_EXIT_CODE;
 		}
 
-		const confStatus = (await cliArweave.transactions.getStatus(txId)).confirmed;
+		const confStatus = (await cliArweave.transactions.getStatus(`${txId}`)).confirmed;
 
 		if (!confStatus?.block_height) {
 			console.log(`${txId}: Not found`);

--- a/src/utils/arfs_builders/arfs_folder_builders.ts
+++ b/src/utils/arfs_builders/arfs_folder_builders.ts
@@ -62,7 +62,7 @@ export class ArFSPublicFolderBuilder extends ArFSFolderBuilder<ArFSPublicFolder>
 			// Get the folder name
 			this.name = dataJSON.name;
 			if (!this.name) {
-				throw new Error('Invalid folder state');
+				throw new Error('Invalid public folder state: name not found!');
 			}
 
 			return Promise.resolve(
@@ -81,7 +81,7 @@ export class ArFSPublicFolderBuilder extends ArFSFolderBuilder<ArFSPublicFolder>
 				)
 			);
 		}
-		throw new Error('Invalid folder state');
+		throw new Error('Invalid public folder state');
 	}
 }
 
@@ -159,7 +159,7 @@ export class ArFSPrivateFolderBuilder extends ArFSFolderBuilder<ArFSPrivateFolde
 			// Get the folder name
 			this.name = decryptedFolderJSON.name;
 			if (!this.name) {
-				throw new Error('Invalid folder state');
+				throw new Error('Invalid private folder state: name not found!');
 			}
 
 			return new ArFSPrivateFolder(
@@ -178,6 +178,6 @@ export class ArFSPrivateFolderBuilder extends ArFSFolderBuilder<ArFSPrivateFolde
 				this.cipherIV
 			);
 		}
-		throw new Error('Invalid folder state');
+		throw new Error('Invalid private folder state');
 	}
 }


### PR DESCRIPTION
•Needed to make sure destructured options variables got fed to type-safe constructors before use with ArDrive class.
• Needed to replace all usages of .includes on arrays of objects to use .some instead.