### PR TITLE
PE-675: Use consistent tags on tip transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-cli",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "The ArDrive Command Line Interface (CLI is a Node.js application for terminal-based ArDrive workflows. It also offers utility operations for securely interacting with Arweave wallets and inspecting various Arweave blockchain conditions.",
 	"main": "./lib/index.js",
 	"bin": {

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -219,6 +219,7 @@ export class ArDrive extends ArDriveAnonymous {
 		return [
 			{ name: 'App-Name', value: this.appName },
 			{ name: 'App-Version', value: this.appVersion },
+			{ name: 'Type', value: 'fee' },
 			{ name: 'Tip-Type', value: tipType }
 		];
 	}

--- a/src/commands/send_ar.ts
+++ b/src/commands/send_ar.ts
@@ -1,4 +1,4 @@
-import { cliWalletDao } from '..';
+import { cliWalletDao, CLI_APP_NAME, CLI_APP_VERSION } from '..';
 import { ArweaveAddress } from '../arweave_address';
 import { CLICommand } from '../CLICommand';
 import { ParametersHelper } from '../CLICommand';
@@ -34,8 +34,8 @@ new CLICommand({
 			rewardSetting,
 			options.dryRun,
 			[
-				{ name: 'App-Name', value: 'ArDrive-CLI' },
-				{ name: 'App-Version', value: '2.0' },
+				{ name: 'App-Name', value: CLI_APP_NAME },
+				{ name: 'App-Version', value: CLI_APP_VERSION },
 				{ name: 'Type', value: 'transfer' }
 			],
 			true

--- a/src/utils/ardrive.test.ts
+++ b/src/utils/ardrive.test.ts
@@ -97,10 +97,14 @@ describe('ArDrive class', () => {
 				{ name: 'App-Version', value: '1.0' }
 			];
 			const inputsAndExpectedOutputs = [
-				[undefined, [...baseTags, { name: 'Tip-Type', value: 'data upload' }]],
-				['data upload', [...baseTags, { name: 'Tip-Type', value: 'data upload' }]]
+				[undefined, [...baseTags, { name: 'Type', value: 'fee' }, { name: 'Tip-Type', value: 'data upload' }]],
+				[
+					'data upload',
+					[...baseTags, { name: 'Type', value: 'fee' }, { name: 'Tip-Type', value: 'data upload' }]
+				]
 			];
 			inputsAndExpectedOutputs.forEach(([input, expectedOutput]) => {
+				console.log(JSON.stringify(expectedOutput, null, 4));
 				expect(arDrive.getTipTags(input as TipType)).to.deep.equal(expectedOutput);
 			});
 		});


### PR DESCRIPTION
This PR changes the tip transaction tags to be consistent with the web app.

Fixes #136