### PR TITLE
fix(create folder): Assert drive privacy during folder creation PE-679

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-cli",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "The ArDrive Command Line Interface (CLI is a Node.js application for terminal-based ArDrive workflows. It also offers utility operations for securely interacting with Arweave wallets and inspecting various Arweave blockchain conditions.",
 	"main": "./lib/index.js",
 	"bin": {

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -521,7 +521,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: UploadPublicFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -610,7 +610,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: BulkPublicUploadParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -817,7 +817,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: UploadPrivateFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId, driveKey);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -920,7 +920,7 @@ export class ArDrive extends ArDriveAnonymous {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
 		// Get owner of drive, will error if no drives are found
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId, driveKey);
 
 		// Assert that the provided wallet is the owner of the drive
 		await this.assertOwnerAddress(owner);
@@ -1134,7 +1134,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async createPublicFolder({ folderName, driveId, parentFolderId }: CreatePublicFolderParams): Promise<ArFSResult> {
-		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Assert that there are no duplicate names in the destination folder
@@ -1179,7 +1179,7 @@ export class ArDrive extends ArDriveAnonymous {
 		driveKey,
 		parentFolderId
 	}: CreatePrivateFolderParams): Promise<ArFSResult> {
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
+		const owner = await this.arFsDao.getOwnerAndAssertDrive(driveId, driveKey);
 		await this.assertOwnerAddress(owner);
 
 		// Assert that there are no duplicate names in the destination folder

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -817,7 +817,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: UploadPrivateFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -920,7 +920,7 @@ export class ArDrive extends ArDriveAnonymous {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
 		// Get owner of drive, will error if no drives are found
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
 
 		// Assert that the provided wallet is the owner of the drive
 		await this.assertOwnerAddress(owner);
@@ -1179,7 +1179,7 @@ export class ArDrive extends ArDriveAnonymous {
 		driveKey,
 		parentFolderId
 	}: CreatePrivateFolderParams): Promise<ArFSResult> {
-		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId, driveKey);
 		await this.assertOwnerAddress(owner);
 
 		// Assert that there are no duplicate names in the destination folder

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -521,7 +521,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: UploadPublicFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -610,7 +610,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: BulkPublicUploadParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -817,7 +817,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}: UploadPrivateFileParams): Promise<ArFSResult> {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Derive destination name and names already within provided destination folder
@@ -920,7 +920,7 @@ export class ArDrive extends ArDriveAnonymous {
 		const driveId = await this.arFsDao.getDriveIdForFolderId(parentFolderId);
 
 		// Get owner of drive, will error if no drives are found
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
 
 		// Assert that the provided wallet is the owner of the drive
 		await this.assertOwnerAddress(owner);

--- a/src/ardrive.ts
+++ b/src/ardrive.ts
@@ -1134,7 +1134,7 @@ export class ArDrive extends ArDriveAnonymous {
 	}
 
 	async createPublicFolder({ folderName, driveId, parentFolderId }: CreatePublicFolderParams): Promise<ArFSResult> {
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPublicDriveId(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Assert that there are no duplicate names in the destination folder
@@ -1179,7 +1179,7 @@ export class ArDrive extends ArDriveAnonymous {
 		driveKey,
 		parentFolderId
 	}: CreatePrivateFolderParams): Promise<ArFSResult> {
-		const owner = await this.getOwnerForDriveId(driveId);
+		const owner = await this.arFsDao.getOwnerForPrivateDriveId(driveId);
 		await this.assertOwnerAddress(owner);
 
 		// Assert that there are no duplicate names in the destination folder

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -917,7 +917,13 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 	}
 
 	public async getOwnerAndAssertDrive(driveId: DriveID, driveKey?: DriveKey): Promise<ArweaveAddress> {
-		const gqlQuery = buildQuery({ tags: [{ name: 'Drive-Id', value: `${driveId}` }], sort: ASCENDING_ORDER });
+		const gqlQuery = buildQuery({
+			tags: [
+				{ name: 'Entity-Type', value: 'drive' },
+				{ name: 'Drive-Id', value: `${driveId}` }
+			],
+			sort: ASCENDING_ORDER
+		});
 		const response = await this.arweave.api.post(graphQLURL, gqlQuery);
 		const edges: GQLEdgeInterface[] = response.data.data.transactions.edges;
 

--- a/src/arfsdao.ts
+++ b/src/arfsdao.ts
@@ -3,7 +3,15 @@ import type { JWKWallet, Wallet } from './wallet';
 import Arweave from 'arweave';
 import { v4 as uuidv4 } from 'uuid';
 import Transaction from 'arweave/node/lib/transaction';
-import { deriveDriveKey, GQLEdgeInterface, GQLNodeInterface, GQLTagInterface, JWKInterface } from 'ardrive-core-js';
+import {
+	deriveDriveKey,
+	GQLEdgeInterface,
+	GQLNodeInterface,
+	GQLTagInterface,
+	JWKInterface,
+	DrivePrivacy,
+	driveDecrypt
+} from 'ardrive-core-js';
 import {
 	ArFSPublicFileDataPrototype,
 	ArFSObjectMetadataPrototype,
@@ -906,6 +914,51 @@ export class ArFSDAO extends ArFSDAOAnonymous {
 			folderId,
 			await this.getAllFoldersOfPublicDrive({ driveId, owner, latestRevisionsOnly: true })
 		);
+	}
+
+	public async getOwnerAndAssertDrive(driveId: DriveID, driveKey?: DriveKey): Promise<ArweaveAddress> {
+		const gqlQuery = buildQuery({ tags: [{ name: 'Drive-Id', value: `${driveId}` }], sort: ASCENDING_ORDER });
+		const response = await this.arweave.api.post(graphQLURL, gqlQuery);
+		const edges: GQLEdgeInterface[] = response.data.data.transactions.edges;
+
+		if (!edges.length) {
+			throw new Error(`Could not find a transaction with "Drive-Id": ${driveId}`);
+		}
+
+		const edgeOfFirstDrive = edges[0];
+
+		const drivePrivacy: DrivePrivacy = driveKey ? 'private' : 'public';
+		const drivePrivacyFromTag = edgeOfFirstDrive.node.tags.find((t) => t.name === 'Drive-Privacy');
+
+		if (!drivePrivacyFromTag) {
+			throw new Error('Target drive has no "Drive-Privacy" tag!');
+		}
+
+		if (drivePrivacyFromTag.value !== drivePrivacy) {
+			throw new Error(`Target drive is not a ${drivePrivacy} drive!`);
+		}
+
+		if (driveKey) {
+			const cipherIVFromTag = edgeOfFirstDrive.node.tags.find((t) => t.name === 'Cipher-IV');
+			if (!cipherIVFromTag) {
+				throw new Error('Target private drive has no "Cipher-IV" tag!');
+			}
+
+			const driveDataBuffer = Buffer.from(
+				await this.arweave.transactions.getData(edgeOfFirstDrive.node.id, { decode: true })
+			);
+
+			try {
+				// Attempt to decrypt drive to assert drive key is correct
+				await driveDecrypt(cipherIVFromTag.value, driveKey, driveDataBuffer);
+			} catch {
+				throw new Error('Provided drive key or password could not decrypt target private drive!');
+			}
+		}
+
+		const driveOwnerAddress = edgeOfFirstDrive.node.owner.address;
+
+		return new ArweaveAddress(driveOwnerAddress);
 	}
 
 	/**

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -46,7 +46,13 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 	}
 
 	public async getOwnerForDriveId(driveId: DriveID): Promise<ArweaveAddress> {
-		const gqlQuery = buildQuery({ tags: [{ name: 'Drive-Id', value: `${driveId}` }], sort: ASCENDING_ORDER });
+		const gqlQuery = buildQuery({
+			tags: [
+				{ name: 'Drive-Id', value: `${driveId}` },
+				{ name: 'Entity-Type', value: 'drive' }
+			],
+			sort: ASCENDING_ORDER
+		});
 		const response = await this.arweave.api.post(graphQLURL, gqlQuery);
 		const edges: GQLEdgeInterface[] = response.data.data.transactions.edges;
 

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -87,7 +87,9 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 					throw new Error('Target private drive has no "Cipher-IV" tag!');
 				}
 
-				const driveDataBuffer = Buffer.from(await this.arweave.transactions.getData(edgeOfFirstDrive.node.id));
+				const driveDataBuffer = Buffer.from(
+					await this.arweave.transactions.getData(edgeOfFirstDrive.node.id, { decode: true })
+				);
 
 				try {
 					// Attempt to decrypt drive to assert drive key is correct

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -46,7 +46,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 	}
 
 	public async getOwnerForPublicDriveId(driveId: DriveID): Promise<ArweaveAddress> {
-		return this.getOwnerForDriveId(driveId, 'private');
+		return this.getOwnerForDriveId(driveId, 'public');
 	}
 
 	public async getOwnerForPrivateDriveId(driveId: DriveID): Promise<ArweaveAddress> {

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -66,7 +66,13 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 
 		if (drivePrivacy) {
 			// Assert drive privacy tag if it has been passed down
-			if (edgeOfFirstDrive.node.tags.find((t) => t.name === 'Drive-Privacy')?.value !== drivePrivacy) {
+			const drivePrivacyFromTag = edgeOfFirstDrive.node.tags.find((t) => t.name === 'Drive-Privacy');
+
+			if (!drivePrivacyFromTag) {
+				throw new Error('Target drive has no "Drive-Privacy" tag!');
+			}
+
+			if (drivePrivacyFromTag.value !== drivePrivacy) {
 				throw new Error(`Target drive is not a ${drivePrivacy} drive!`);
 			}
 		}

--- a/src/arfsdao_anonymous.ts
+++ b/src/arfsdao_anonymous.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import Arweave from 'arweave';
-import { ArFSDriveEntity, driveDecrypt, DrivePrivacy, GQLEdgeInterface } from 'ardrive-core-js';
+import { ArFSDriveEntity, GQLEdgeInterface } from 'ardrive-core-js';
 import { ASCENDING_ORDER, buildQuery } from './query';
-import { DriveID, FolderID, FileID, DEFAULT_APP_NAME, DEFAULT_APP_VERSION, EntityID, DriveKey } from './types';
+import { DriveID, FolderID, FileID, DEFAULT_APP_NAME, DEFAULT_APP_VERSION, EntityID } from './types';
 import { latestRevisionFilter, latestRevisionFilterForDrives } from './utils/filter_methods';
 import { FolderHierarchy } from './folderHierarchy';
 import { ArFSPublicDriveBuilder, SafeArFSDriveBuilder } from './utils/arfs_builders/arfs_drive_builders';
@@ -45,19 +45,7 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		super();
 	}
 
-	public async getOwnerForPublicDriveId(driveId: DriveID): Promise<ArweaveAddress> {
-		return this.getOwnerForDriveId(driveId, true);
-	}
-
-	public async getOwnerForPrivateDriveId(driveId: DriveID, driveKey: DriveKey): Promise<ArweaveAddress> {
-		return this.getOwnerForDriveId(driveId, true, driveKey);
-	}
-
-	public async getOwnerForDriveId(
-		driveId: DriveID,
-		assertPrivacy = false,
-		driveKey?: DriveKey
-	): Promise<ArweaveAddress> {
+	public async getOwnerForDriveId(driveId: DriveID): Promise<ArweaveAddress> {
 		const gqlQuery = buildQuery({ tags: [{ name: 'Drive-Id', value: `${driveId}` }], sort: ASCENDING_ORDER });
 		const response = await this.arweave.api.post(graphQLURL, gqlQuery);
 		const edges: GQLEdgeInterface[] = response.data.data.transactions.edges;
@@ -67,38 +55,6 @@ export class ArFSDAOAnonymous extends ArFSDAOType {
 		}
 
 		const edgeOfFirstDrive = edges[0];
-
-		if (assertPrivacy) {
-			// Conditionally assert drive privacy when methods need to
-			const drivePrivacy: DrivePrivacy = driveKey ? 'private' : 'public';
-			const drivePrivacyFromTag = edgeOfFirstDrive.node.tags.find((t) => t.name === 'Drive-Privacy');
-
-			if (!drivePrivacyFromTag) {
-				throw new Error('Target drive has no "Drive-Privacy" tag!');
-			}
-
-			if (drivePrivacyFromTag.value !== drivePrivacy) {
-				throw new Error(`Target drive is not a ${drivePrivacy} drive!`);
-			}
-
-			if (drivePrivacyFromTag.value === 'private' && driveKey) {
-				const cipherIVFromTag = edgeOfFirstDrive.node.tags.find((t) => t.name === 'Cipher-IV');
-				if (!cipherIVFromTag) {
-					throw new Error('Target private drive has no "Cipher-IV" tag!');
-				}
-
-				const driveDataBuffer = Buffer.from(
-					await this.arweave.transactions.getData(edgeOfFirstDrive.node.id, { decode: true })
-				);
-
-				try {
-					// Attempt to decrypt drive to assert drive key is correct
-					await driveDecrypt(cipherIVFromTag.value, driveKey, driveDataBuffer);
-				} catch {
-					throw new Error('Provided drive key or password could not decrypt target private drive!');
-				}
-			}
-		}
 
 		const driveOwnerAddress = edgeOfFirstDrive.node.owner.address;
 

--- a/tests/integration/ardrive.int.test.ts
+++ b/tests/integration/ardrive.int.test.ts
@@ -126,7 +126,7 @@ describe('ArDrive class - integrated', () => {
 			});
 
 			it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
-				stub(arfsDao, 'getOwnerForDriveId').resolves(unexpectedOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPublicFolder({
@@ -139,7 +139,7 @@ describe('ArDrive class - integrated', () => {
 			});
 
 			it('throws an error if the folder name conflicts with another ENTITY name in the destination folder', async () => {
-				stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPublicFolder({
@@ -152,7 +152,7 @@ describe('ArDrive class - integrated', () => {
 			});
 
 			it('returns the correct ArFSResult', async () => {
-				stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 				stub(arfsDao, 'getPublicDrive').resolves(stubPublicDrive);
 
 				const result = await arDrive.createPublicFolder({
@@ -170,7 +170,7 @@ describe('ArDrive class - integrated', () => {
 			});
 
 			it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
-				stub(arfsDao, 'getOwnerForDriveId').resolves(unexpectedOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPrivateFolder({
@@ -184,7 +184,7 @@ describe('ArDrive class - integrated', () => {
 			});
 
 			it('throws an error if the folder name conflicts with another ENTITY name in the destination folder', async () => {
-				stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 				await expectAsyncErrorThrow({
 					promiseToError: arDrive.createPrivateFolder({
@@ -199,7 +199,7 @@ describe('ArDrive class - integrated', () => {
 
 			it('returns the correct ArFSResult', async () => {
 				stub(arfsDao, 'getPrivateDrive').resolves(stubPrivateDrive);
-				stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+				stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 				const stubDriveKey = await getStubDriveKey();
 				const result = await arDrive.createPrivateFolder({
@@ -474,7 +474,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(unexpectedOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.uploadPublicFile({ parentFolderId: stubEntityID, wrappedFile }),
@@ -483,7 +483,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('throws an error if destination folder has a conflicting FOLDER name', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.uploadPublicFile({
@@ -496,7 +496,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct empty ArFSResult if destination folder has a conflicting FILE name and conflict resolution is set to skip', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					const result = await arDrive.uploadPublicFile({
 						parentFolderId: stubEntityID,
@@ -513,7 +513,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult revision if destination folder has a conflicting FILE name and conflict resolution is set to replace', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					const result = await arDrive.uploadPublicFile({
 						parentFolderId: stubEntityID,
@@ -527,7 +527,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns an empty ArFSResult if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => matchingLastModifiedDate);
 
 					const result = await arDrive.uploadPublicFile({
@@ -545,7 +545,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult revision if destination folder has a conflicting FILE name and a different last modified date and the conflict resolution is set to upsert', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => differentLastModifiedDate);
 
 					const result = await arDrive.uploadPublicFile({
@@ -560,7 +560,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					const result = await arDrive.uploadPublicFile({ parentFolderId: stubEntityID, wrappedFile });
 					assertUploadFileExpectations(result, 3204, 166, 0, '1', 'public');
@@ -587,7 +587,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('throws an error if the owner of the drive conflicts with supplied wallet', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(unexpectedOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(unexpectedOwner);
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.uploadPrivateFile({
@@ -600,7 +600,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('throws an error if destination folder has a conflicting FOLDER name', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					await expectAsyncErrorThrow({
 						promiseToError: arDrive.uploadPrivateFile({
@@ -614,7 +614,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct empty ArFSResult if destination folder has a conflicting FILE name and conflict resolution is set to skip', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					const result = await arDrive.uploadPrivateFile({
 						parentFolderId: stubEntityID,
@@ -632,7 +632,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult revision with if destination folder has a conflicting FILE name and conflict resolution is set to replace', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 
 					const result = await arDrive.uploadPrivateFile({
 						parentFolderId: stubEntityID,
@@ -647,7 +647,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns an empty ArFSResult if destination folder has a conflicting FILE name and a matching last modified date and the conflict resolution is set to upsert', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => matchingLastModifiedDate);
 
 					const result = await arDrive.uploadPrivateFile({
@@ -666,7 +666,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult revision if destination folder has a conflicting FILE name and a different last modified date and the conflict resolution is set to upsert', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					stub(wrappedFile, 'lastModifiedDate').get(() => differentLastModifiedDate);
 
 					const result = await arDrive.uploadPrivateFile({
@@ -682,7 +682,7 @@ describe('ArDrive class - integrated', () => {
 				});
 
 				it('returns the correct ArFSResult', async () => {
-					stub(arfsDao, 'getOwnerForDriveId').resolves(walletOwner);
+					stub(arfsDao, 'getOwnerAndAssertDrive').resolves(walletOwner);
 					const stubDriveKey = await getStubDriveKey();
 
 					const result = await arDrive.uploadPrivateFile({


### PR DESCRIPTION
This PR asserts the drive privacy of a folder creation during the GQL call to derive the drive owner.

As this is a hotfix, the version has been bumped here and the target branch is `master`. Proposed GitHub release notes:

- Creating private entities inside public drives and public entities inside private drives will now cause an error
- Creating private entities with the wrong drive key or password will now cause an error