### PR TITLE
refactor(stubs): Use CLI side stub PE-701

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ardrive-cli",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "The ArDrive Command Line Interface (CLI is a Node.js application for terminal-based ArDrive workflows. It also offers utility operations for securely interacting with Arweave wallets and inspecting various Arweave blockchain conditions.",
 	"main": "./lib/index.js",
 	"bin": {
@@ -8,7 +8,7 @@
 	},
 	"types": "./lib/index.d.ts",
 	"dependencies": {
-		"ardrive-core-js": "1.0.0",
+		"ardrive-core-js": "../ardrive-core-js",
 		"arweave": "^1.10.16",
 		"commander": "^8.2.0",
 		"lodash": "^4.17.21",

--- a/src/CLICommand/parameters_helper.test.ts
+++ b/src/CLICommand/parameters_helper.test.ts
@@ -28,9 +28,9 @@ import {
 import '../parameter_declarations';
 import { CLIAction } from './action';
 import { SUCCESS_EXIT_CODE } from './error_codes';
-import { stubArweaveAddress, EID, urlEncodeHashKey } from 'ardrive-core-js';
+import { ArweaveAddress, EID, urlEncodeHashKey } from 'ardrive-core-js';
 
-const expectedArweaveAddress = stubArweaveAddress('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
+const expectedArweaveAddress = new ArweaveAddress('P8aFJizMVBl7HeoRAz2i1dNYkG_KoN7oB9tZpIw6lo4');
 
 const dummyActionHandler = () => Promise.resolve(SUCCESS_EXIT_CODE);
 


### PR DESCRIPTION
This PR removes the stub imported by Core, because it is no longer being exported. Our tests should not rely on stubs from upstream dependencies anyhow