### PR TITLE
PE-781: consolidate flag aliases

### DIFF
--- a/src/commands/download_folder.ts
+++ b/src/commands/download_folder.ts
@@ -5,17 +5,17 @@ import { CLIAction } from '../CLICommand/action';
 import {
 	DrivePrivacyParameters,
 	FolderIdParameter,
-	DestinationFolderPathParameter,
+	LocalPathParameter,
 	MaxDepthParameter
 } from '../parameter_declarations';
 
 new CLICommand({
 	name: 'download-folder',
-	parameters: [FolderIdParameter, DestinationFolderPathParameter, MaxDepthParameter, ...DrivePrivacyParameters],
+	parameters: [FolderIdParameter, LocalPathParameter, MaxDepthParameter, ...DrivePrivacyParameters],
 	action: new CLIAction(async (options) => {
 		const parameters = new ParametersHelper(options);
 		const folderId = parameters.getRequiredParameterValue(FolderIdParameter, EID);
-		const destFolderPath = parameters.getParameterValue(DestinationFolderPathParameter) || './';
+		const destFolderPath = parameters.getParameterValue(LocalPathParameter) || './';
 		const maxDepth = await parameters.getMaxDepth(Number.MAX_SAFE_INTEGER);
 
 		if (await parameters.getIsPrivate()) {

--- a/src/commands/upload_file.ts
+++ b/src/commands/upload_file.ts
@@ -5,8 +5,8 @@ import {
 	DestinationFileNameParameter,
 	DrivePrivacyParameters,
 	DryRunParameter,
-	LocalFilePathParameter,
-	LocalFilesParameter,
+	LocalPathParameter,
+	LocalPathsCSVParameter,
 	ParentFolderIdParameter,
 	WalletFileParameter
 } from '../parameter_declarations';
@@ -36,9 +36,9 @@ new CLICommand({
 	name: 'upload-file',
 	parameters: [
 		ParentFolderIdParameter,
-		LocalFilePathParameter,
+		LocalPathParameter,
 		DestinationFileNameParameter,
-		LocalFilesParameter,
+		LocalPathsCSVParameter,
 		BoostParameter,
 		DryRunParameter,
 		...ConflictResolutionParams,
@@ -47,7 +47,7 @@ new CLICommand({
 	action: new CLIAction(async function action(options) {
 		const parameters = new ParametersHelper(options);
 		const filesToUpload: UploadFileParameter[] = await (async function (): Promise<UploadFileParameter[]> {
-			const localFiles = parameters.getParameterValue(LocalFilesParameter);
+			const localFiles = parameters.getParameterValue(LocalPathsCSVParameter);
 			if (localFiles) {
 				const COLUMN_SEPARATOR = ',';
 				const ROW_SEPARATOR = '.';
@@ -72,12 +72,8 @@ new CLICommand({
 				return fileParameters;
 			}
 
-			if (!options.localFilePath) {
-				throw new Error('Must provide a local file path!');
-			}
-
 			const parentFolderId: FolderID = parameters.getRequiredParameterValue(ParentFolderIdParameter, EID);
-			const localFilePath = parameters.getRequiredParameterValue(LocalFilePathParameter, wrapFileOrFolder);
+			const localFilePath = parameters.getRequiredParameterValue(LocalPathParameter, wrapFileOrFolder);
 			const singleParameter = {
 				parentFolderId: parentFolderId,
 				wrappedEntity: localFilePath,

--- a/src/parameter_declarations.ts
+++ b/src/parameter_declarations.ts
@@ -19,11 +19,10 @@ export const ConfirmationsParameter = 'confirmations';
 export const FolderIdParameter = 'folderId';
 export const FileIdParameter = 'fileId';
 export const ParentFolderIdParameter = 'parentFolderId';
-export const LocalFilePathParameter = 'localFilePath';
-export const DestinationFolderPathParameter = 'destFolderPath';
+export const LocalPathParameter = 'localPath';
 export const DestinationFileNameParameter = 'destFileName';
 export const DestinationManifestNameParameter = 'destManifestName';
-export const LocalFilesParameter = 'localFiles';
+export const LocalPathsCSVParameter = 'localPathsCsv';
 export const GetAllRevisionsParameter = 'getAllRevisions';
 export const AllParameter = 'all';
 export const MaxDepthParameter = 'maxDepth';
@@ -57,8 +56,8 @@ export const AllParameters = [
 	FolderNameParameter,
 	GetAllRevisionsParameter,
 	LastTxParameter,
-	LocalFilesParameter,
-	LocalFilePathParameter,
+	LocalPathsCSVParameter,
+	LocalPathParameter,
 	MaxDepthParameter,
 	NoVerifyParameter,
 	ParentFolderIdParameter,
@@ -227,16 +226,9 @@ Parameter.declare({
 });
 
 Parameter.declare({
-	name: LocalFilePathParameter,
-	aliases: ['-l', '--local-file-path'],
-	description: `the path on the local filesystem for the file that will be uploaded`
-});
-
-Parameter.declare({
-	name: DestinationFolderPathParameter,
-	aliases: ['-d', '--dest-folder-path'],
-	description: `the path on the local filesystem of the folder`,
-	forbiddenConjunctionParameters: [LocalFilePathParameter]
+	name: LocalPathParameter,
+	aliases: ['-l', '--local-path'],
+	description: `a path in the local storage`
 });
 
 Parameter.declare({
@@ -252,8 +244,8 @@ Parameter.declare({
 });
 
 Parameter.declare({
-	name: LocalFilesParameter,
-	aliases: ['--local-files'],
+	name: LocalPathsCSVParameter,
+	aliases: ['--local-paths-csv'],
 	description: `(BETA) a path to a csv (tab delimited) file containing rows of data for the following columns:
 \t\t\t\t\t\t\t• CSV Columns:
 \t\t\t\t\t\t\t\t• local file path
@@ -262,7 +254,7 @@ Parameter.declare({
 \t\t\t\t\t\t\t\t\t• --parent-folder-id used, otherwise
 \t\t\t\t\t\t\t• all parent folder IDs should reside in the same drive
 \t\t\t\t\t\t\t• Can NOT be used in conjunction with --local-file-path`,
-	forbiddenConjunctionParameters: [LocalFilePathParameter]
+	forbiddenConjunctionParameters: [LocalPathParameter]
 });
 
 Parameter.declare({


### PR DESCRIPTION
Simplifies the parameter aliases for paths:
- `--local-file-path` and `--dest-folder-path` are consolidated to `--local-path`
- `--local-files` is renamed to `--local-paths-csv`

Still pending: the `--local-paths` parameter at https://github.com/karlprieb/ardrive-cli/pull/1