### PR TITLE
test(download file): implement unit tests PE-464

### DIFF
--- a/src/utils/local_file_path.test.ts
+++ b/src/utils/local_file_path.test.ts
@@ -1,12 +1,19 @@
 import { expect } from 'chai';
+import { join as joinPath } from 'path';
 import { stub } from 'sinon';
 import { getOutputFilePathAndName } from './local_file_path';
 
-const PATH_EXISTING_FOLDER = '/my/existing/folder';
-const PATH_EXISTING_FILE = '/my/existing/file.txt';
-const PATH_UNEXISTANT_FOLDER = '/some/unexisting/folder';
-const PATH_UNEXISTANT_FILE = '/my/existing/folder/file.txt';
-const PATH_EXISTING_SOCKET = '/my/existing/socket';
+const NAME_EXSTING_FOLDER_NAME = 'EXISTING_folder';
+const NAME_EXISTING_FILE = 'EXISTING_file.txt';
+const NAME_EXISTING_NON_FILE = 'EXISTING_socket_or_symbolic_link';
+const NAME_NONEXISTENT_FILE = 'NONEXISTENT_crazy_file_with_cool_stuff.doc';
+
+const PATH_EXISTING_PARENT_FOLDER = '/my/existing';
+const PATH_EXISTING_FOLDER = joinPath(PATH_EXISTING_PARENT_FOLDER, NAME_EXSTING_FOLDER_NAME);
+const PATH_EXISTING_FILE = joinPath(PATH_EXISTING_PARENT_FOLDER, NAME_EXISTING_FILE);
+const PATH_EXISTING_NON_FILE = joinPath(PATH_EXISTING_PARENT_FOLDER, NAME_EXISTING_NON_FILE);
+const PATH_NONEXISTENT_FILE = joinPath(PATH_EXISTING_FOLDER, NAME_NONEXISTENT_FILE);
+const PATH_NONEXISTENT_FOLDER = '/some/NONEXISTENT/folder';
 
 const mockStatsFolder = {
 	isDirectory: () => true,
@@ -30,14 +37,15 @@ describe('getOutputFilePathAndName function', () => {
 	};
 
 	before(() => {
+		// makes the resolve function to return the same given path
 		fsStatSyncAndPathResolveWrapper.resolve.returnsArg(0);
-	});
 
-	beforeEach(() => {
+		// makes the stubbed statsSync method to return a mocked fs.Stats for each corresponding case
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_PARENT_FOLDER).returns(mockStatsFolder);
 		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_FOLDER).returns(mockStatsFolder);
-		fsStatSyncAndPathResolveWrapper.statSync.withArgs('/my/existing').returns(mockStatsFolder);
 		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_FILE).returns(mockStatsFile);
-		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_SOCKET).returns(mockStatsNotFileNorFolder);
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_NON_FILE).returns(mockStatsNotFileNorFolder);
+		// the stub throws for the nonexistent paths
 		fsStatSyncAndPathResolveWrapper.statSync.throws();
 	});
 
@@ -49,23 +57,23 @@ describe('getOutputFilePathAndName function', () => {
 
 	it('returns the parent path and the basename if the file exists', () => {
 		expect(getOutputFilePathAndName(PATH_EXISTING_FILE, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
-			'/my/existing',
-			'file.txt'
+			PATH_EXISTING_PARENT_FOLDER,
+			NAME_EXISTING_FILE
 		]);
 	});
 
 	it("returns the parent path and the basename if it doesn't exist, but the parent does", () => {
-		expect(getOutputFilePathAndName(PATH_UNEXISTANT_FILE, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
-			'/my/existing/folder',
-			'file.txt'
+		expect(getOutputFilePathAndName(PATH_NONEXISTENT_FILE, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
+			PATH_EXISTING_FOLDER,
+			NAME_NONEXISTENT_FILE
 		]);
 	});
 
 	it("throws if the path isn't a file nor a directory", () => {
-		expect(() => getOutputFilePathAndName(PATH_EXISTING_SOCKET, fsStatSyncAndPathResolveWrapper)).to.throw();
+		expect(() => getOutputFilePathAndName(PATH_EXISTING_NON_FILE, fsStatSyncAndPathResolveWrapper)).to.throw();
 	});
 
 	it('throws if the path nor its parent exist', () => {
-		expect(() => getOutputFilePathAndName(PATH_UNEXISTANT_FOLDER, fsStatSyncAndPathResolveWrapper)).to.throw();
+		expect(() => getOutputFilePathAndName(PATH_NONEXISTENT_FOLDER, fsStatSyncAndPathResolveWrapper)).to.throw();
 	});
 });

--- a/src/utils/local_file_path.test.ts
+++ b/src/utils/local_file_path.test.ts
@@ -49,7 +49,7 @@ describe('getOutputFilePathAndName function', () => {
 		fsStatSyncAndPathResolveWrapper.statSync.throws();
 	});
 
-	it('returns only the providen path if it is a directory', () => {
+	it('returns only the provided path if it is a directory', () => {
 		expect(getOutputFilePathAndName(PATH_EXISTING_FOLDER, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
 			PATH_EXISTING_FOLDER
 		]);

--- a/src/utils/local_file_path.test.ts
+++ b/src/utils/local_file_path.test.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { getOutputFilePathAndName } from './local_file_path';
+
+const PATH_EXISTING_FOLDER = '/my/existing/folder';
+const PATH_EXISTING_FILE = '/my/existing/file.txt';
+const PATH_UNEXISTANT_FOLDER = '/some/unexisting/folder';
+const PATH_UNEXISTANT_FILE = '/my/existing/folder/file.txt';
+const PATH_EXISTING_SOCKET = '/my/existing/socket';
+
+const mockStatsFolder = {
+	isDirectory: () => true,
+	isFile: () => false
+};
+
+const mockStatsFile = {
+	isDirectory: () => false,
+	isFile: () => true
+};
+
+const mockStatsNotFileNorFolder = {
+	isDirectory: () => false,
+	isFile: () => false
+};
+
+describe('getOutputFilePathAndName function', () => {
+	const fsStatSyncAndPathResolveWrapper = {
+		statSync: stub(),
+		resolve: stub()
+	};
+
+	before(() => {
+		fsStatSyncAndPathResolveWrapper.resolve.returnsArg(0);
+	});
+
+	beforeEach(() => {
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_FOLDER).returns(mockStatsFolder);
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs('/my/existing').returns(mockStatsFolder);
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_FILE).returns(mockStatsFile);
+		fsStatSyncAndPathResolveWrapper.statSync.withArgs(PATH_EXISTING_SOCKET).returns(mockStatsNotFileNorFolder);
+		fsStatSyncAndPathResolveWrapper.statSync.throws();
+	});
+
+	it('returns only the providen path if it is a directory', () => {
+		expect(getOutputFilePathAndName(PATH_EXISTING_FOLDER, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
+			PATH_EXISTING_FOLDER
+		]);
+	});
+
+	it('returns the parent path and the basename if the file exists', () => {
+		expect(getOutputFilePathAndName(PATH_EXISTING_FILE, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
+			'/my/existing',
+			'file.txt'
+		]);
+	});
+
+	it("returns the parent path and the basename if it doesn't exist, but the parent does", () => {
+		expect(getOutputFilePathAndName(PATH_UNEXISTANT_FILE, fsStatSyncAndPathResolveWrapper)).to.deep.equal([
+			'/my/existing/folder',
+			'file.txt'
+		]);
+	});
+
+	it("throws if the path isn't a file nor a directory", () => {
+		expect(() => getOutputFilePathAndName(PATH_EXISTING_SOCKET, fsStatSyncAndPathResolveWrapper)).to.throw();
+	});
+
+	it('throws if the path nor its parent exist', () => {
+		expect(() => getOutputFilePathAndName(PATH_UNEXISTANT_FOLDER, fsStatSyncAndPathResolveWrapper)).to.throw();
+	});
+});

--- a/src/utils/local_file_path.test.ts
+++ b/src/utils/local_file_path.test.ts
@@ -73,7 +73,7 @@ describe('getOutputFilePathAndName function', () => {
 		expect(() => getOutputFilePathAndName(PATH_EXISTING_NON_FILE, fsStatSyncAndPathResolveWrapper)).to.throw();
 	});
 
-	it('throws if the path nor its parent exist', () => {
+	it('throws if neither the path nor its parent exist', () => {
 		expect(() => getOutputFilePathAndName(PATH_NONEXISTENT_FOLDER, fsStatSyncAndPathResolveWrapper)).to.throw();
 	});
 });

--- a/src/utils/local_file_path.test.ts
+++ b/src/utils/local_file_path.test.ts
@@ -69,7 +69,7 @@ describe('getOutputFilePathAndName function', () => {
 		]);
 	});
 
-	it("throws if the path isn't a file nor a directory", () => {
+	it("throws if the path is neither a file nor a directory", () => {
 		expect(() => getOutputFilePathAndName(PATH_EXISTING_NON_FILE, fsStatSyncAndPathResolveWrapper)).to.throw();
 	});
 

--- a/src/utils/local_file_path.ts
+++ b/src/utils/local_file_path.ts
@@ -3,17 +3,25 @@ import { basename, dirname, resolve } from 'path';
 
 export type FilePathAndName = [string, string?];
 
+const fsStatSyncAndPathResolve = {
+	statSync,
+	resolve
+};
+
 /**
  * Resolves the path, verifies its existance and type to conditionally return its dir and file name
  * @param {string} destOutputPath - the path from where to extract the dir path and name
  * @returns {FilePathAndName} - the directory where to put the file and the file name (which is undefined when the provided destOutputPath is a directory)
  */
-export function getOutputFilePathAndName(destOutputPath: string): FilePathAndName {
-	const resolvedOutputPath = resolve(destOutputPath);
+export function getOutputFilePathAndName(
+	destOutputPath: string,
+	fsStatSyncAndPathResolveWrapper = fsStatSyncAndPathResolve
+): FilePathAndName {
+	const resolvedOutputPath = fsStatSyncAndPathResolveWrapper.resolve(destOutputPath);
 	const outputDirname = dirname(resolvedOutputPath);
 	const outputBasename = basename(resolvedOutputPath);
 	try {
-		const outputPathStats = statSync(resolvedOutputPath);
+		const outputPathStats = fsStatSyncAndPathResolveWrapper.statSync(resolvedOutputPath);
 		// the destination does exist
 		if (outputPathStats.isDirectory()) {
 			// and is a directory
@@ -25,7 +33,7 @@ export function getOutputFilePathAndName(destOutputPath: string): FilePathAndNam
 		throw new Error(`The destination isn't a folder nor a file!`);
 	} catch (e) {
 		// the destination doesn't exist
-		const outputParentPathStats = statSync(outputDirname);
+		const outputParentPathStats = fsStatSyncAndPathResolveWrapper.statSync(outputDirname);
 		// the parent exists
 		if (outputParentPathStats.isDirectory()) {
 			return [outputDirname, outputBasename];

--- a/src/utils/local_file_path.ts
+++ b/src/utils/local_file_path.ts
@@ -30,7 +30,6 @@ export function getOutputFilePathAndName(
 			// as an existing file
 			return [outputDirname, outputBasename];
 		}
-		throw new Error(`The destination isn't a folder nor a file!`);
 	} catch (e) {
 		// the destination doesn't exist
 		const outputParentPathStats = fsStatSyncAndPathResolveWrapper.statSync(outputDirname);
@@ -40,4 +39,5 @@ export function getOutputFilePathAndName(
 		}
 		throw new Error(`The path ${outputDirname} is not a directory!`);
 	}
+	throw new Error(`The destination isn't a folder nor a file!`);
 }

--- a/src/utils/local_file_path.ts
+++ b/src/utils/local_file_path.ts
@@ -3,6 +3,10 @@ import { basename, dirname, resolve } from 'path';
 
 export type FilePathAndName = [string, string?];
 
+/**
+ * For testing purposes.
+ * This object is the default value of the last argument of getOutputFilePathAndName
+ */
 const fsStatSyncAndPathResolve = {
 	statSync,
 	resolve

--- a/src/utils/local_file_path.ts
+++ b/src/utils/local_file_path.ts
@@ -43,5 +43,5 @@ export function getOutputFilePathAndName(
 		}
 		throw new Error(`The path ${outputDirname} is not a directory!`);
 	}
-	throw new Error(`The destination isn't a folder nor a file!`);
+	throw new Error(`The destination is neither a folder nor a file!`);
 }


### PR DESCRIPTION
Adds missing tests for the `getOutputFilePathAndName` function.
Also fixes the broken test on which the `switch..case` caught the exception I was throwing