### PR TITLE
fix(arweave version): Lock arweave version to avoid getData 1.10.19 error PE-845

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"types": "./lib/index.d.ts",
 	"dependencies": {
 		"ardrive-core-js": "1.4.0",
-		"arweave": "^1.10.18",
+		"arweave": "1.10.18",
 		"axios": "^0.21.1",
 		"commander": "^8.2.0",
 		"lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,7 +1521,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.18.0
     "@typescript-eslint/parser": ^4.18.0
     ardrive-core-js: 1.4.0
-    arweave: ^1.10.18
+    arweave: 1.10.18
     axios: ^0.21.1
     chai: ^4.3.4
     commander: ^8.2.0
@@ -1636,7 +1636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arweave@npm:^1.10.0, arweave@npm:^1.10.15, arweave@npm:^1.10.18":
+"arweave@npm:1.10.18, arweave@npm:^1.10.0, arweave@npm:^1.10.15, arweave@npm:^1.10.18":
   version: 1.10.18
   resolution: "arweave@npm:1.10.18"
   dependencies:


### PR DESCRIPTION
This PR locks the arweave version to 1.10.18. We encounted an error on the transaction.getData method 