### PR TITLE
PE-636: Send community tip with the data tx or bundle tx

### DIFF
--- a/bats_test/upload-file/single-bundled-files.bats
+++ b/bats_test/upload-file/single-bundled-files.bats
@@ -30,21 +30,19 @@ setup_file() {
     assert_line -n 1 ''
 }
 
-@test "upload bundled file produces two fees" {
+@test "upload bundled file produces one fee" {
     run -0 bash -c "yarn ardrive upload-file --dry-run -l '/home/node/10Chunks.txt' -F $PUB_FOLD_ID -w $WALLET | jq '.fees'"
 
     assert_line -n 0 '{'
     assert_line -n 1 --regexp '(\s){0,}("){1}(\w|-){43}("){1}'
-    assert_line -n 2 --regexp '(\s){0,}("){1}(\w|-){43}("){1}'
-    assert_line -n 3 '}'   
+    assert_line -n 2 '}'   
 }
 
-@test "upload file as v2 transactions produces three fees" {
+@test "upload file as v2 transactions produces two fees" {
     run -0 bash -c "yarn ardrive upload-file --no-bundle --dry-run -l '/home/node/10Chunks.txt' -F $PUB_FOLD_ID -w $WALLET | jq '.fees'"
 
     assert_line -n 0 '{'
     assert_line -n 1 --regexp '(\s){0,}("){1}(\w|-){43}("){1}'
     assert_line -n 2 --regexp '(\s){0,}("){1}(\w|-){43}("){1}'
-    assert_line -n 3 --regexp '(\s){0,}("){1}(\w|-){43}("){1}'
-    assert_line -n 4 '}'
+    assert_line -n 3 '}'
 }


### PR DESCRIPTION
This PR adds the ArDrive community tip to the bundle transaction or the data transaction during v2 uploads by applying the changes from this [Core PR](https://github.com/ardriveapp/ardrive-core-js/pull/115). 