### PR TITLE
test(seed phrase): Double timeout to deter false build failures PE-1005

### DIFF
--- a/src/CLICommand/parameters_helper.test.ts
+++ b/src/CLICommand/parameters_helper.test.ts
@@ -246,7 +246,7 @@ describe('ParametersHelper class', () => {
 
 		it('returns a wallet when a valid --seed-phrase option is provided', function () {
 			// FIXME: it takes too long
-			this.timeout(60_000);
+			this.timeout(120_000);
 			const cmd = declareCommandWithParams(program, [SeedPhraseParameter]);
 			CLICommand.parse(program, [
 				...baseArgv,


### PR DESCRIPTION
This PR should make false build failures from the unpredictably long seed phrase test more infrequent