### PR TITLE
PE-1066: Failing BATS for download-drive

### DIFF
--- a/bats_test/downloads/drive-downloads/happy_paths.bats
+++ b/bats_test/downloads/drive-downloads/happy_paths.bats
@@ -39,9 +39,6 @@ setup() {
 }
 
 @test "Download drive to a custom folder using a custom depth of 0" {
-    # Skipped for now as test is failing, but the command itself is working properly. PE-1066
-    skip
-
     cd "${DIR}"
     run -0 download_public_drive "${MY_DRIVE_ID}" "${DIR}/MyCustomFolderName" "0"
 


### PR DESCRIPTION
It was a failing BATS test before the release (#261). We figured out that the command would work as expected when running by hand. The day after (today) I ran the test again and it seem to pass as expected.

My conclusion is that there was some condition at the docker environment in that specific instance I had as we weren't able to reproduce in a fresh one.