### PR TITLE
test(ipfs): adds a test for ipfs with private entities PE-1987

### DIFF
--- a/src/CLICommand/cli_command.test.ts
+++ b/src/CLICommand/cli_command.test.ts
@@ -7,7 +7,9 @@ import {
 	DriveNameParameter,
 	UnsafeDrivePasswordParameter,
 	SeedPhraseParameter,
-	WalletFileParameter
+	WalletFileParameter,
+	IPFSParameter,
+	PrivateParameter
 } from '../parameter_declarations';
 import { CliApiObject } from './cli';
 import { baseArgv } from './test_constants';
@@ -47,6 +49,15 @@ const commandDescriptorForbiddenWalletFileAndSeedPhrase: CommandDescriptor = {
 const parsedCommandOptionsBothSpecified = {
 	[WalletFileParameter]: nonEmptyValue,
 	[SeedPhraseParameter]: nonEmptyValue
+};
+const commandDescriptorIPFSAndPrivate: CommandDescriptor = {
+	name: testingCommandName,
+	parameters: [IPFSParameter, PrivateParameter],
+	action: new CLIAction(dummyAction)
+};
+const parsedCommandOptionsIPFSAndPrivate = {
+	[PrivateParameter]: true,
+	[IPFSParameter]: true
 };
 
 class TestCliApiObject {
@@ -103,7 +114,10 @@ describe('CLICommand class', () => {
 				commandDescriptorForbiddenWalletFileAndSeedPhrase,
 				parsedCommandOptionsBothSpecified
 			);
-		}).to.throw();
+		}).to.throw('Parameter walletFile cannot be used in conjunction with seedPhrase');
+		expect(function () {
+			assertConjunctionParameters(commandDescriptorIPFSAndPrivate, parsedCommandOptionsIPFSAndPrivate);
+		}).to.throw('Parameter addIpfsTag cannot be used in conjunction with private');
 	});
 
 	it('No colliding parameters', () => {

--- a/src/CLICommand/parameters_helper.test.ts
+++ b/src/CLICommand/parameters_helper.test.ts
@@ -29,8 +29,7 @@ import {
 	MetaDataFileParameter,
 	MetaDataGqlTagsParameter,
 	MetadataJsonParameter,
-	IPFSParameter,
-	DataGqlTagsParameter
+	IPFSParameter
 } from '../parameter_declarations';
 import '../parameter_declarations';
 import { CLIAction } from './action';


### PR DESCRIPTION
Changes
- Adds a unit tests to ensure --add-ipfs-flag and --private are disallowed in conjunction